### PR TITLE
feat: Add free trial support and enhance UI/error handling

### DIFF
--- a/weco/panels.py
+++ b/weco/panels.py
@@ -221,7 +221,7 @@ class MetricTreePanel:
                 text = "bug"
             else:
                 # evaluated non-buggy node
-                if node.id == best_node.id:
+                if best_node is not None and node.id == best_node.id:
                     # best node
                     color = "green"
                     style = "bold"


### PR DESCRIPTION
Updates the CLI to support the new free trial feature implemented in the meta-agent API. This includes prompting users for their own LLM API keys when free trial steps are exhausted. Additionally, this commit improves the display of errors from the backend and fixes UI rendering bugs.

Key Changes:
- API Interaction (`weco/api.py`):
  - `handle_api_error`: Modified to only print detailed error messages and not exit, allowing the main CLI logic to manage termination and display errors more robustly within the Rich Live context.
  - `evaluate_feedback_then_suggest_next_solution`:
    - Specifically handles 402 Payment Required HTTP errors (indicating exhausted free steps) by returning the JSON error payload for the CLI to process.
    - Re-raises other HTTPErrors after printing, enabling centralized error handling in `cli.py`.
- CLI Logic (`weco/cli.py`):
  - When a 402 error with `{"error": "api_key_required"}` is received, the CLI now prompts the user to enter their LLM API keys.
  - If keys are provided, the failed step is retried using these new keys.
  - If no keys are provided or the retry also fails, the run is terminated.
  - The main exception handler in `cli.py` now more effectively catches and displays errors propagated from API calls using a Rich Panel for better visibility.
  - Integrates device login flow for authenticated operations.
- UI Panels (`weco/panels.py`):
  - `MetricTreePanel`: Fixed an `AttributeError` that occurred when `best_node` was `None`. Added a check for `best_node is not None` before accessing `best_node.id` during the rendering of the solution tree, preventing a CLI crash.