### PR TITLE
fix: truncate long output

### DIFF
--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -34,7 +34,6 @@ from .utils import (
     read_from_path,
     write_to_path,
     run_evaluation,
-    truncate_output,
     smooth_update,
     format_number,
 )
@@ -250,7 +249,6 @@ def execute_optimization(
 
             # Run evaluation on the initial solution
             term_out = run_evaluation(eval_command=eval_command)
-            term_out = truncate_output(term_out, max_lines=50, max_chars=5000)
             # Update the evaluation output panel
             eval_output_panel.update(output=term_out)
             smooth_update(
@@ -350,7 +348,6 @@ def execute_optimization(
                     transition_delay=0.08,  # Slightly longer delay for more noticeable transitions
                 )
                 term_out = run_evaluation(eval_command=eval_command)
-                term_out = truncate_output(term_out, max_lines=50, max_chars=5000)
                 eval_output_panel.update(output=term_out)
                 smooth_update(
                     live=live,

--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -34,6 +34,7 @@ from .utils import (
     read_from_path,
     write_to_path,
     run_evaluation,
+    truncate_output,
     smooth_update,
     format_number,
 )
@@ -249,6 +250,7 @@ def execute_optimization(
 
             # Run evaluation on the initial solution
             term_out = run_evaluation(eval_command=eval_command)
+            term_out = truncate_output(term_out, max_lines=50, max_chars=5000)
             # Update the evaluation output panel
             eval_output_panel.update(output=term_out)
             smooth_update(
@@ -348,6 +350,7 @@ def execute_optimization(
                     transition_delay=0.08,  # Slightly longer delay for more noticeable transitions
                 )
                 term_out = run_evaluation(eval_command=eval_command)
+                term_out = truncate_output(term_out, max_lines=50, max_chars=5000)
                 eval_output_panel.update(output=term_out)
                 smooth_update(
                     live=live,

--- a/weco/utils.py
+++ b/weco/utils.py
@@ -150,7 +150,8 @@ def run_evaluation(eval_command: str) -> str:
         if len(output) > 0:
             output += "\n"
         output += result.stdout
-    return output
+
+    return truncate_output(output)
 
 
 # Update Check Function

--- a/weco/utils.py
+++ b/weco/utils.py
@@ -124,6 +124,20 @@ def smooth_update(
 
 
 # Other helper functions
+def truncate_output(output: str, max_lines: int = 50, max_chars: int = 5000) -> str:
+    """Truncate the output to a reasonable size."""
+    lines = output.splitlines()
+    if len(lines) > max_lines:
+        output = "\n".join(lines[-max_lines:])
+        output = f"... (truncated to last {max_lines} lines)\n{output}"
+
+    if len(output) > max_chars:
+        output = output[-max_chars:]
+        output = f"... (truncated to last {max_chars} characters)\n{output}"
+
+    return output
+
+
 def run_evaluation(eval_command: str) -> str:
     """Run the evaluation command on the code and return the output."""
 

--- a/weco/utils.py
+++ b/weco/utils.py
@@ -146,9 +146,9 @@ def truncate_output(output: str, max_lines: int = DEFAULT_MAX_LINES, max_chars: 
     # Add prefixes for truncations that were applied
     prefixes = []
     if lines_truncated:
-        prefixes.append(f"... (truncated to last {max_lines} lines)")
+        prefixes.append(f"truncated to last {max_lines} lines")
     if chars_truncated:
-        prefixes.append(f"... (truncated to last {max_chars} characters)")
+        prefixes.append(f"truncated to last {max_chars} characters")
 
     if prefixes:
         prefix_text = ", ".join(prefixes)

--- a/weco/utils.py
+++ b/weco/utils.py
@@ -124,7 +124,10 @@ def smooth_update(
 
 
 # Other helper functions
-def truncate_output(output: str, max_lines: int = 50, max_chars: int = 5000) -> str:
+DEFAULT_MAX_LINES = 50
+DEFAULT_MAX_CHARS = 5000
+
+def truncate_output(output: str, max_lines: int = DEFAULT_MAX_LINES, max_chars: int = DEFAULT_MAX_CHARS) -> str:
     """Truncate the output to a reasonable size."""
     lines = output.splitlines()
     if len(lines) > max_lines:

--- a/weco/utils.py
+++ b/weco/utils.py
@@ -130,14 +130,29 @@ DEFAULT_MAX_CHARS = 5000
 def truncate_output(output: str, max_lines: int = DEFAULT_MAX_LINES, max_chars: int = DEFAULT_MAX_CHARS) -> str:
     """Truncate the output to a reasonable size."""
     lines = output.splitlines()
-    if len(lines) > max_lines:
+    
+    # Determine what truncations are needed based on original output
+    lines_truncated = len(lines) > max_lines
+    chars_truncated = len(output) > max_chars
+    
+    # Apply truncations to the original output
+    if lines_truncated:
         output = "\n".join(lines[-max_lines:])
-        output = f"... (truncated to last {max_lines} lines)\n{output}"
-
-    if len(output) > max_chars:
+    
+    if chars_truncated:
         output = output[-max_chars:]
-        output = f"... (truncated to last {max_chars} characters)\n{output}"
-
+    
+    # Add prefixes for truncations that were applied
+    prefixes = []
+    if lines_truncated:
+        prefixes.append(f"... (truncated to last {max_lines} lines)")
+    if chars_truncated:
+        prefixes.append(f"... (truncated to last {max_chars} characters)")
+    
+    if prefixes:
+        prefix_text = ", ".join(prefixes)
+        output = f"... ({prefix_text})\n{output}"
+    
     return output
 
 

--- a/weco/utils.py
+++ b/weco/utils.py
@@ -127,32 +127,33 @@ def smooth_update(
 DEFAULT_MAX_LINES = 50
 DEFAULT_MAX_CHARS = 5000
 
+
 def truncate_output(output: str, max_lines: int = DEFAULT_MAX_LINES, max_chars: int = DEFAULT_MAX_CHARS) -> str:
     """Truncate the output to a reasonable size."""
     lines = output.splitlines()
-    
+
     # Determine what truncations are needed based on original output
     lines_truncated = len(lines) > max_lines
     chars_truncated = len(output) > max_chars
-    
+
     # Apply truncations to the original output
     if lines_truncated:
         output = "\n".join(lines[-max_lines:])
-    
+
     if chars_truncated:
         output = output[-max_chars:]
-    
+
     # Add prefixes for truncations that were applied
     prefixes = []
     if lines_truncated:
         prefixes.append(f"... (truncated to last {max_lines} lines)")
     if chars_truncated:
         prefixes.append(f"... (truncated to last {max_chars} characters)")
-    
+
     if prefixes:
         prefix_text = ", ".join(prefixes)
         output = f"... ({prefix_text})\n{output}"
-    
+
     return output
 
 


### PR DESCRIPTION
Some execution results have too long output and leading the 413 error
```bash
╭───────────────────────────── Optimization Error ─────────────────────────────╮
│ Error: 413 Client Error: Request Entity Too Large for url:                   │
│ https://api.weco.ai/v1/runs/a0fa10d7-3e4e-487b-b52e-5f8ba4cc0c68/suggest     │
╰──────────────────────────────────────────────────────────────────────────────╯
```