### PR TITLE
fix: reduce exec output size

### DIFF
--- a/weco/constants.py
+++ b/weco/constants.py
@@ -5,3 +5,7 @@ Constants for the Weco CLI package.
 
 # API timeout configuration (connect_timeout, read_timeout) in seconds
 DEFAULT_API_TIMEOUT = (10, 800)
+
+# Default max lines and chars for output truncation
+DEFAULT_MAX_LINES = 50
+DEFAULT_MAX_CHARS = 2500


### PR DESCRIPTION
Seeing the error from some of the runs (`dev` branch)
```
 Error: Unable to add new solution to solution history. Please restart the run.
```

I think it was caused by json payload too large and weco fails to send via `evaluate_feedback_then_suggest_next_solutio` weco/api.py

