### PR TITLE
feat: Add weco resume command for interrupted runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,37 @@ To save your optimization runs and view them on the Weco dashboard, you can log 
 | `weco` | Launch interactive onboarding | **Recommended for beginners** - Analyzes your codebase and guides you through setup |
 | `weco /path/to/project` | Launch onboarding for specific project | When working with a project in a different directory |
 | `weco run [options]` | Direct optimization execution | **For advanced users** - When you know exactly what to optimize and how |
+| `weco resume <run-id> [options]` | Resume an interrupted optimization | When a run was interrupted and you want to continue from the last completed step |
 | `weco logout` | Clear authentication credentials | To switch accounts or troubleshoot authentication issues |
+
+### Resuming Interrupted Runs
+
+If your optimization run is interrupted (due to network issues, system restart, etc.), you can resume it from the last completed step using the `weco resume` command:
+
+```bash
+# Resume a run from where it left off
+weco resume abc-123-def
+
+# Resume and add 20 more steps to the original run
+weco resume abc-123-def --extend 20
+
+# Skip validation prompts and resume immediately
+weco resume abc-123-def --skip-validation
+```
+
+**Arguments for `weco resume`:**
+
+| Argument | Description | Example |
+|----------|-------------|---------|
+| `run-id` | The ID of the run to resume (shown at the start of each run) | `abc-123-def` |
+| `--extend` | Add additional steps to the original run limit | `--extend 50` |
+| `--skip-validation` | Skip environment validation checks | `--skip-validation` |
+
+**Important notes:**
+- The resume feature only works for runs that have at least one completed step (with execution output)
+- You'll be prompted to confirm that your evaluation environment hasn't changed since the original run
+- The source file will be restored to the last completed solution before continuing
+- All progress and metrics from the original run are preserved
 
 ### Model Selection
 

--- a/weco/api.py
+++ b/weco/api.py
@@ -348,3 +348,34 @@ def analyze_script_execution_requirements(
     except Exception as e:
         console.print(f"[bold red]Error: {e}[/]")
         return f"python {script_path}"
+
+
+def resume_optimization_run(
+    console: Console,
+    run_id: str,
+    extend_steps: Optional[int] = None,
+    api_keys: Dict[str, Any] = {},
+    auth_headers: dict = {},
+    timeout: Union[int, Tuple[int, int]] = DEFAULT_API_TIMEOUT,
+) -> Optional[Dict[str, Any]]:
+    """Resume an optimization run from the last completed step."""
+    with console.status(f"[bold green]Resuming run {run_id}..."):
+        try:
+            response = requests.post(
+                f"{__base_url__}/runs/{run_id}/resume",
+                json={
+                    "extend_steps": extend_steps,
+                    "metadata": {"client_name": "cli", "client_version": __pkg_version__, **api_keys},
+                },
+                headers=auth_headers,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            result = response.json()
+            return result
+        except requests.exceptions.HTTPError as e:
+            handle_api_error(e, console)
+            return None
+        except Exception as e:
+            console.print(f"[bold red]Error resuming run: {e}[/]")
+            return None


### PR DESCRIPTION
- Add 'weco resume <run-id>' command with --extend and --skip-validation flags
- Implement resume_optimization() function with full optimization flow
- Add validation prompts to confirm environment hasn't changed
- Restore last completed solution to source file before continuing
- Update README with comprehensive resume command documentation

CLI changes:
- New resume subcommand in cli.py
- resume_optimization_run() API function for backend communication
- Environment validation with user confirmation (can be skipped)
- Proper step counting from last completed step
- Reuse existing panels and heartbeat infrastructure

Documentation:
- Add detailed resume command section to README
- Include usage examples and argument descriptions
- Explain when resume works (needs at least one completed step)

🤖 Generated with [Claude Code](https://claude.ai/code)