### PR TITLE
Update supported models list to include codex mini and GPT 5 models from OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,12 @@ Weco will parse this output to extract the numerical value (1.5 in this case) as
 Weco supports the following LLM models:
 
 ### OpenAI Models
-- `o3`
+- `gpt-5`
+- `gpt-5-mini`
+- `gpt-5-nano`
+- `o3` (recommended)
 - `o3-mini`
-- `o4-mini`
+- `o4-mini` (recommended)
 - `o1-pro`
 - `o1`
 - `gpt-4.1`
@@ -240,6 +243,7 @@ Weco supports the following LLM models:
 - `gpt-4.1-nano`
 - `gpt-4o`
 - `gpt-4o-mini`
+- `codex-mini-latest`
 
 ### Anthropic Models
 - `claude-opus-4-1`


### PR DESCRIPTION
This pull request updates the list of supported OpenAI models in the `README.md` file to reflect new and recommended models. The changes clarify which models are recommended and add several new model options.

Updates to supported OpenAI models:

* Added new models: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, and `codex-mini-latest` to the list of supported OpenAI models.
* Marked `o3` and `o4-mini` as recommended models in the documentation.