### PR TITLE
handle potential read timeouts due to intermediaries dropping long running tcp connections

### DIFF
--- a/weco/api.py
+++ b/weco/api.py
@@ -101,6 +101,7 @@ def resume_optimization_run(
 def evaluate_feedback_then_suggest_next_solution(
     console: Console,
     run_id: str,
+    step: int,
     execution_output: str,
     additional_instructions: str = None,
     auth_headers: dict = {},
@@ -124,8 +125,44 @@ def evaluate_feedback_then_suggest_next_solution(
             result["plan"] = ""
         if result.get("code") is None:
             result["code"] = ""
-
         return result
+    except requests.exceptions.ReadTimeout as e:
+        # NOTE: This can occur when:
+        # 1. The server is busy and the request times out
+        # 2. When intermediaries drop the connection so even after the server responds,
+        # the client doesn't receive the response and times out
+
+        # Here we ONLY try to recover in the latter case i.e., server completed request but
+        # client didn't receive the response and timed out
+        run_status_recovery_response = get_optimization_run_status(
+            console=console, run_id=run_id, include_history=True, auth_headers=auth_headers
+        )
+        current_step = run_status_recovery_response.get("current_step")
+        current_status = run_status_recovery_response.get("status")
+        # The run should be "running" and the current step should correspond to the solution step we are attempting to generate
+        is_valid_run_state = current_status is not None and current_status == "running"
+        is_valid_step = current_step is not None and current_step == step
+        if is_valid_run_state and is_valid_step:
+            nodes = run_status_recovery_response.get("nodes") or []
+            # We need at least 2 nodes to reconstruct the expected response i.e., the last two nodes
+            if len(nodes) >= 2:
+                nodes_sorted_ascending = sorted(nodes, key=lambda n: n["step"])
+                latest_node = nodes_sorted_ascending[-1]
+                penultimate_node = nodes_sorted_ascending[-2]
+                # If the server finished generating the next candidate, it should be exactly this step
+                if latest_node and latest_node["step"] == step:
+                    # Try to reconstruct the expected response from the /suggest endpoint using the run status info
+                    reconstructed_expected_response = {
+                        "run_id": run_id,
+                        "previous_solution_metric_value": penultimate_node.get("metric_value"),
+                        "solution_id": latest_node.get("solution_id"),
+                        "code": latest_node.get("code"),
+                        "plan": latest_node.get("plan"),
+                        "is_done": False,
+                    }
+                    return reconstructed_expected_response
+        # If we couldn't recover, raise the timeout error so the run can be resumed by the user
+        raise requests.exceptions.ReadTimeout(e)
     except requests.exceptions.HTTPError as e:
         # Allow caller to handle suggest errors, maybe retry or terminate
         handle_api_error(e, console)

--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -358,6 +358,7 @@ def execute_optimization(
                 # Send feedback and get next suggestion
                 eval_and_next_solution_response = evaluate_feedback_then_suggest_next_solution(
                     console=console,
+                    step=step,
                     run_id=run_id,
                     execution_output=term_out,
                     additional_instructions=current_additional_instructions,
@@ -420,6 +421,7 @@ def execute_optimization(
                 # Evaluate the final solution thats been generated
                 eval_and_next_solution_response = evaluate_feedback_then_suggest_next_solution(
                     console=console,
+                    step=steps,
                     run_id=run_id,
                     execution_output=term_out,
                     additional_instructions=current_additional_instructions,
@@ -728,6 +730,7 @@ def resume_optimization(run_id: str, console: Optional[Console] = None) -> bool:
                 # Suggest next
                 eval_and_next_solution_response = evaluate_feedback_then_suggest_next_solution(
                     console=console,
+                    step=step,
                     run_id=resume_resp["run_id"],
                     execution_output=term_out,
                     additional_instructions=additional_instructions,
@@ -783,6 +786,7 @@ def resume_optimization(run_id: str, console: Optional[Console] = None) -> bool:
             if not user_stop_requested_flag:
                 eval_and_next_solution_response = evaluate_feedback_then_suggest_next_solution(
                     console=console,
+                    step=total_steps,
                     run_id=resume_resp["run_id"],
                     execution_output=term_out,
                     additional_instructions=additional_instructions,


### PR DESCRIPTION
This pull request introduces improved handling of timeout errors in the optimization run workflow and ensures that the correct step information is passed when evaluating feedback and suggesting the next solution. The main focus is on making the system more robust to network or server-side timeouts by attempting to recover the expected response from the run status, minimizing unnecessary interruptions for the user.

**Error Handling Improvements:**

* Added logic in `evaluate_feedback_then_suggest_next_solution` (in `weco/api.py`) to detect `ReadTimeout` exceptions, attempt to recover the expected response by querying the run status, and reconstruct the response if possible. If recovery is not possible, the timeout is re-raised to allow user intervention.

**API and Function Signature Updates:**

* Updated the signature of `evaluate_feedback_then_suggest_next_solution` to require a `step` parameter, ensuring that the current step is always available for recovery logic.

**Call Site Updates:**

* Updated all calls to `evaluate_feedback_then_suggest_next_solution` in `weco/optimizer.py` to pass the appropriate `step` value, aligning with the new function signature and supporting accurate recovery.