### PR TITLE
use triton.testing.do_bench() whenever possible for benchmarking

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ pip install weco>=0.2.18
 | :-- | :-- | :-- | :-- |
 | 🧭 Hello Kernel World | Learn the Weco workflow on a small PyTorch model | `torch` | [README](hello-kernel-world/README.md) • [Colab](hello-kernel-world/colab_notebook_walkthrough.ipynb) |
 | ⚡ Triton Optimization | Speed up attention with Triton kernels | `torch`, `triton` | [README](triton/README.md) |
-| 🚀 CUDA Optimization | Generate low-level CUDA kernels for max speed | `torch`, `ninja`, NVIDIA GPU + CUDA Toolkit | [README](cuda/README.md) |
+| 🚀 CUDA Optimization | Generate low-level CUDA kernels for max speed | `torch`, `ninja`, `triton`, NVIDIA GPU + CUDA Toolkit | [README](cuda/README.md) |
 | 🧠 Prompt Engineering | Iteratively refine LLM prompts to improve accuracy | `openai`, `datasets` | [README](prompt/README.md) |
 | 🛰️ Spaceship Titanic | Improve a Kaggle model training pipeline | `pandas`, `numpy`, `scikit-learn`, `torch`, `xgboost`, `lightgbm`, `catboost` | [README](spaceship-titanic/README.md) |
 
@@ -70,7 +70,7 @@ weco run --source optimize.py \
 
 ### 🚀 CUDA Optimization
 
-- **Install extra deps**: `pip install torch ninja`
+- **Install extra deps**: `pip install torch ninja triton`
 - **Requires**: NVIDIA GPU and CUDA Toolkit
 - **Run**:
 ```bash

--- a/examples/cuda/README.md
+++ b/examples/cuda/README.md
@@ -18,7 +18,7 @@ export OPENAI_API_KEY="your_key_here"
 
 Install the required dependencies:
 ```bash
-pip install torch ninja
+pip install torch ninja triton
 ```
 > **Note:** This example requires a compatible NVIDIA GPU and the CUDA Toolkit installed on your system for compiling and running the generated CUDA code.
 

--- a/examples/cuda/evaluate.py
+++ b/examples/cuda/evaluate.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
+from triton.testing import do_bench
 
 
 ########################################################
@@ -78,29 +79,6 @@ def get_inputs(batch_size, seq_len, n_embd, device):
     return torch.randn(batch_size, seq_len, n_embd, device=device, dtype=torch.float32)
 
 
-@torch.no_grad()
-def bench(f, inputs, n_warmup, n_rep):
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-
-    # warmup
-    for _ in range(n_warmup):
-        f(inputs)  # noqa
-    torch.cuda.synchronize()
-
-    # benchmark
-    t_avg_ms = 0.0
-    for _ in range(n_rep):
-        # time the forward pass
-        start_event.record()
-        f(inputs)
-        end_event.record()
-        # wait for all computations to complete
-        torch.cuda.synchronize()
-        t_avg_ms += start_event.elapsed_time(end_event)
-    return t_avg_ms / n_rep
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -111,8 +89,8 @@ if __name__ == "__main__":
     # benchmarking parameters
     n_correctness_trials = 10
     correctness_tolerance = 1e-5
-    n_warmup = 1000
-    n_rep = 5000
+    warmup_ms = 1e3
+    rep_ms = 5 * 1e3
 
     # init parameters
     max_seqlen = 512
@@ -158,8 +136,8 @@ if __name__ == "__main__":
 
     # measure performance
     inputs = get_inputs(batch_size=batch_size, seq_len=seq_len, n_embd=n_embd, device="cuda")
-    t_avg_baseline = bench(baseline_model, inputs, n_warmup, n_rep)
+    t_avg_baseline = do_bench(lambda: baseline_model(inputs), warmup=warmup_ms, rep=rep_ms)
     print(f"baseline time: {t_avg_baseline:.2f}ms")
-    t_avg_optimized = bench(solution_model, inputs, n_warmup, n_rep)
+    t_avg_optimized = do_bench(lambda: solution_model(inputs), warmup=warmup_ms, rep=rep_ms)
     print(f"optimized time: {t_avg_optimized:.2f}ms")
     print(f"speedup: {t_avg_baseline / t_avg_optimized:.2f}x")

--- a/examples/hello-kernel-world/evaluate.py
+++ b/examples/hello-kernel-world/evaluate.py
@@ -61,6 +61,11 @@ def get_inputs(B, N, device):
     return torch.randn(B, N, device=device, dtype=torch.float32)
 
 
+# NOTE: We included this custom benchmark function to avoid adding the triton dependency
+# and allow users to run the example on CPUs. However, if you have an NVIDIA GPU,
+# you can use the triton.testing.do_bench function instead.
+# Refer to examples/triton/evaluate.py for an example.
+# triton.testing.do_bench documentation: https://triton-lang.org/main/python-api/generated/triton.testing.do_bench.html
 @torch.no_grad()
 def bench(f, inputs, n_warmup, n_rep):
     device_type = inputs.device.type

--- a/examples/triton/evaluate.py
+++ b/examples/triton/evaluate.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
+from triton.testing import do_bench
 
 
 ########################################################
@@ -74,28 +75,6 @@ def get_inputs(batch_size, seq_len, n_embd, device):
     return torch.randn(batch_size, seq_len, n_embd, device=device, dtype=torch.float32)
 
 
-@torch.no_grad()
-def bench(f, inputs, n_warmup, n_rep):
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-
-    # warmup
-    for _ in range(n_warmup):
-        f(inputs)  # noqa
-    torch.cuda.synchronize()
-
-    # benchmark
-    t_avg_ms = 0.0
-    for _ in range(n_rep):
-        start_event.record()
-        f(inputs)
-        end_event.record()
-        # wait for all computations to complete
-        torch.cuda.synchronize()
-        t_avg_ms += start_event.elapsed_time(end_event)
-    return t_avg_ms / n_rep
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -106,8 +85,8 @@ if __name__ == "__main__":
     # benchmarking parameters
     n_correctness_trials = 10
     correctness_tolerance = 1e-5
-    n_warmup = 1000
-    n_rep = 5000
+    warmup_ms = 1e3
+    rep_ms = 5 * 1e3
 
     # init parameters
     max_seqlen = 512
@@ -153,8 +132,8 @@ if __name__ == "__main__":
 
     # measure performance
     inputs = get_inputs(batch_size=batch_size, seq_len=seq_len, n_embd=n_embd, device="cuda")
-    t_avg_baseline = bench(baseline_model, inputs, n_warmup, n_rep)
+    t_avg_baseline = do_bench(lambda: baseline_model(inputs), warmup=warmup_ms, rep=rep_ms)
     print(f"baseline time: {t_avg_baseline:.2f}ms")
-    t_avg_optimized = bench(solution_model, inputs, n_warmup, n_rep)
+    t_avg_optimized = do_bench(lambda: solution_model(inputs), warmup=warmup_ms, rep=rep_ms)
     print(f"optimized time: {t_avg_optimized:.2f}ms")
     print(f"speedup: {t_avg_baseline / t_avg_optimized:.2f}x")


### PR DESCRIPTION
This pull request updates the CUDA and Triton optimization examples to improve benchmarking and clarify dependencies. The main changes include switching to Triton's built-in benchmarking utility, updating documentation to require the `triton` package, and adding clarifying comments to avoid unnecessary dependencies in simple examples.

**Documentation and Dependency Updates:**
* Updated all relevant `README.md` files and install instructions to include `triton` as a required dependency for CUDA optimization examples. 

**Benchmarking Improvements:**
* Replaced the custom `bench` function in `examples/cuda/evaluate.py` and `examples/triton/evaluate.py` with Triton's `do_bench` utility for more accurate and standardized benchmarking. 
* Changed benchmarking parameters from fixed iteration counts to time-based measurements (`warmup_ms` and `rep_ms`) for more robust performance evaluation. 

**Codebase Clarification:**
* Added comments in `examples/hello-kernel-world/evaluate.py` to explain the use of a custom benchmark function for CPU compatibility and reference the Triton benchmarking utility for users with GPUs.