### PR TITLE
Merge Dev - Add derive subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "weco"
 authors = [{ name = "Weco AI Team", email = "contact@weco.ai" }]
 description = "Documentation for `weco`, a CLI for using Weco AI's code optimizer."
 readme = "README.md"
-version = "0.3.29"
+version = "0.3.30"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_derive_handler.py
+++ b/tests/test_derive_handler.py
@@ -27,17 +27,10 @@ from weco.optimizer import OptimizationResult
 # ---------------------------------------------------------------------------
 
 
-_FAKE_DERIVED_FROM = {
-    "run_id": "parent-id",
-    "node_id": "n1",
-    "step": 1,
-    "metric_value": 0.7,
-}
+_FAKE_DERIVED_FROM = {"run_id": "parent-id", "node_id": "n1", "step": 1, "metric_value": 0.7}
 
 
-def _fake_derive_response(
-    *, candidate_code: dict[str, str] | None = None, **run_overrides
-) -> dict:
+def _fake_derive_response(*, candidate_code: dict[str, str] | None = None, **run_overrides) -> dict:
     """Build a canonical successful derive response.
 
     Override any field in the inner ``run`` dict via kwargs (e.g.
@@ -105,10 +98,7 @@ def patched():
     ``patched.plain_ui.on_init`` (or ``live_ui.on_init``) for inspection.
     """
     with (
-        patch(
-            "weco.commands.run.derive.handle_authentication",
-            return_value=("api-key", {"Authorization": "Bearer t"}),
-        ),
+        patch("weco.commands.run.derive.handle_authentication", return_value=("api-key", {"Authorization": "Bearer t"})),
         patch("weco.commands.run.derive.WecoClient") as MockClient,
         patch("weco.commands.run.derive.run_optimization_loop") as mock_loop,
         patch("weco.heartbeat.HeartbeatSender"),
@@ -234,12 +224,7 @@ def test_from_step_wiring(patched, from_step, expected_derive_from, expects_look
 
 
 @pytest.mark.parametrize(
-    "loop_kwarg, expected",
-    [
-        ("eval_command", "python test.py"),
-        ("save_logs", True),
-        ("eval_timeout", 600),
-    ],
+    "loop_kwarg, expected", [("eval_command", "python test.py"), ("save_logs", True), ("eval_timeout", 600)]
 )
 def test_loop_config_inherited_from_response(patched, loop_kwarg, expected):
     """The loop receives its config from the derive response, not from
@@ -266,10 +251,7 @@ def test_additional_instructions_flow_through_to_derive_run(patched):
     """The (resolved) --additional-instructions value reaches the backend.
     Locks in the rename from the older `direction` field name."""
     _call_handle(additional_instructions="focus on memory efficiency")
-    assert (
-        patched.client.derive_run.call_args.kwargs["additional_instructions"]
-        == "focus on memory efficiency"
-    )
+    assert patched.client.derive_run.call_args.kwargs["additional_instructions"] == "focus on memory efficiency"
 
 
 # ---------------------------------------------------------------------------
@@ -283,8 +265,7 @@ def test_originals_use_inherited_source_when_local_files_missing(patched, tmp_pa
     pollute the working directory with generated code on every eval cycle."""
     monkeypatch.chdir(tmp_path)  # empty directory: no local files
     patched.client.derive_run.return_value = _fake_derive_response(
-        source_code={"main.py": "INHERITED"},
-        candidate_code={"main.py": "CANDIDATE"},
+        source_code={"main.py": "INHERITED"}, candidate_code={"main.py": "CANDIDATE"}
     )
 
     _call_handle()
@@ -298,9 +279,7 @@ def test_originals_prefer_local_files_when_present(patched, tmp_path, monkeypatc
     the user may have made local edits since the parent run."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "main.py").write_text("LOCAL_EDITED")
-    patched.client.derive_run.return_value = _fake_derive_response(
-        source_code={"main.py": "INHERITED"}
-    )
+    patched.client.derive_run.return_value = _fake_derive_response(source_code={"main.py": "INHERITED"})
 
     _call_handle()
 
@@ -313,8 +292,7 @@ def test_originals_prefer_local_files_when_present(patched, tmp_path, monkeypatc
 
 
 @pytest.mark.parametrize(
-    "output_mode, expected_ui, other_ui",
-    [("plain", "plain_ui", "live_ui"), ("rich", "live_ui", "plain_ui")],
+    "output_mode, expected_ui, other_ui", [("plain", "plain_ui", "live_ui"), ("rich", "live_ui", "plain_ui")]
 )
 def test_handler_picks_ui_for_output_mode(patched, output_mode, expected_ui, other_ui):
     """Plain mode constructs PlainOptimizationUI, rich mode constructs
@@ -346,9 +324,7 @@ def test_handler_returns_false_when_loop_fails(patched):
     """Failed loop must propagate as ``False`` — the dispatcher relies on
     this to set the process exit code. Loop *success* is covered implicitly
     by every other test in this file (the default fixture exercises it)."""
-    patched.loop.return_value = OptimizationResult(
-        success=False, final_step=3, status="error", reason="submit_failed"
-    )
+    patched.loop.return_value = OptimizationResult(success=False, final_step=3, status="error", reason="submit_failed")
     assert _call_handle() is False
 
 
@@ -379,9 +355,7 @@ def test_plain_mode_skips_unchanged_files_prompt(patched):
 
 
 @pytest.mark.parametrize(
-    "loop_success, expect_apply_called",
-    [(True, True), (False, False)],
-    ids=["success-applies-best", "failure-skips-apply"],
+    "loop_success, expect_apply_called", [(True, True), (False, False)], ids=["success-applies-best", "failure-skips-apply"]
 )
 def test_apply_best_only_after_successful_loop(patched, loop_success, expect_apply_called):
     patched.loop.return_value = OptimizationResult(
@@ -424,11 +398,7 @@ def test_api_errors_exit_cleanly_with_code_1(patched, make_exception):
     assert exc.value.code == 1
 
 
-@pytest.mark.parametrize(
-    "output_mode, expect_json_in_stderr",
-    [("plain", True), ("rich", False)],
-    ids=["plain", "rich"],
-)
+@pytest.mark.parametrize("output_mode, expect_json_in_stderr", [("plain", True), ("rich", False)], ids=["plain", "rich"])
 def test_derive_error_routed_through_correct_channel(patched, capsys, output_mode, expect_json_in_stderr):
     """A DeriveError reaches the user via stderr+JSON in plain mode and
     styled console output in rich mode. Plain mode in particular must never

--- a/tests/test_derive_handler.py
+++ b/tests/test_derive_handler.py
@@ -1,0 +1,476 @@
+"""Unit tests for the ``weco run derive`` command handler.
+
+Mocks every external boundary the handler touches (auth, HTTP client,
+optimization loop, heartbeat thread, browser, artifacts, prompts, UI
+classes) so the handler can be exercised end-to-end with no network, no
+auth, no LLM, and no real threads.
+
+Tests are organized by *what they verify*, not by historical bug reference.
+``_resolve_step_to_node_id`` is unit-tested directly; the rest exercise
+``derive.handle`` end-to-end via the ``patched`` fixture.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from rich.console import Console
+
+from weco.commands.run import derive
+from weco.optimizer import OptimizationResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+_FAKE_DERIVED_FROM = {
+    "run_id": "parent-id",
+    "node_id": "n1",
+    "step": 1,
+    "metric_value": 0.7,
+}
+
+
+def _fake_derive_response(
+    *, candidate_code: dict[str, str] | None = None, **run_overrides
+) -> dict:
+    """Build a canonical successful derive response.
+
+    Override any field in the inner ``run`` dict via kwargs (e.g.
+    ``_fake_derive_response(eval_timeout=900)``). Override the candidate
+    code via the explicit ``candidate_code`` kwarg.
+    """
+    run = {
+        "id": "new-run-id",
+        "name": "derived-test",
+        "status": "running",
+        "lineage_id": "parent-id",
+        "derived_from": _FAKE_DERIVED_FROM,
+        # Loop-config fields the CLI consumes:
+        "evaluation_command": "python test.py",
+        "metric_name": "score",
+        "maximize": True,
+        "steps": 12,
+        "model": "gpt-4",
+        "eval_timeout": 600,
+        "save_logs": True,
+        "log_dir": ".weco-runs",
+        "source_code": {"main.py": "INHERITED"},
+    }
+    run.update(run_overrides)
+    return {
+        "run": run,
+        "candidate": {
+            "run_id": run["id"],
+            "run_name": run["name"],
+            "solution_id": "sol-1",
+            "code": candidate_code or {"main.py": "CANDIDATE"},
+            "plan": "try x",
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        },
+    }
+
+
+# Default kwargs for derive.handle. Most tests don't care about presentation
+# so plain mode is the default — it skips the interactive Confirm prompt and
+# emits machine-readable error JSON, both of which simplify assertions.
+_DEFAULT_CALL_KWARGS = dict(
+    run_id="parent-id",
+    from_step="best",
+    steps=None,
+    additional_instructions=None,
+    api_keys=None,
+    output_mode="plain",
+    console=None,  # filled in per-call so each test gets a fresh Console
+)
+
+
+def _call_handle(**overrides):
+    """Invoke ``derive.handle`` with sane defaults; overrides win."""
+    kwargs = _DEFAULT_CALL_KWARGS | {"console": Console()} | overrides
+    return derive.handle(**kwargs)
+
+
+@pytest.fixture
+def patched():
+    """Patch every external boundary derive.handle touches.
+
+    Yields a ``SimpleNamespace`` of the most useful mock handles. Both UI
+    classes are configured so that ``with ui_instance as ui:`` yields the
+    same mock instance — that way ``ui.on_init(...)`` lands directly on
+    ``patched.plain_ui.on_init`` (or ``live_ui.on_init``) for inspection.
+    """
+    with (
+        patch(
+            "weco.commands.run.derive.handle_authentication",
+            return_value=("api-key", {"Authorization": "Bearer t"}),
+        ),
+        patch("weco.commands.run.derive.WecoClient") as MockClient,
+        patch("weco.commands.run.derive.run_optimization_loop") as mock_loop,
+        patch("weco.heartbeat.HeartbeatSender"),
+        patch("weco.commands.run.derive.RunArtifacts") as mock_artifacts,
+        patch("weco.commands.run.derive.report_termination"),
+        patch("weco.commands.run.derive.offer_apply_best_solution") as mock_apply,
+        patch("weco.commands.run.derive.Confirm") as MockConfirm,
+        patch("weco.commands.run.derive.LiveOptimizationUI") as MockLiveUI,
+        patch("weco.commands.run.derive.PlainOptimizationUI") as MockPlainUI,
+    ):
+        # Defaults: loop succeeds, prompts say yes.
+        mock_loop.return_value = OptimizationResult(
+            success=True, final_step=2, status="completed", reason="completed_successfully"
+        )
+        MockConfirm.ask.return_value = True
+
+        # Make `with ui as x:` yield the outer mock so ui.on_init calls land
+        # on the same object the test inspects.
+        for mock_ui_cls in (MockLiveUI, MockPlainUI):
+            mock_ui_cls.return_value.__enter__.return_value = mock_ui_cls.return_value
+
+        client = MockClient.return_value
+        client.derive_run.return_value = _fake_derive_response()
+
+        yield SimpleNamespace(
+            client=client,
+            loop=mock_loop,
+            artifacts=mock_artifacts,
+            apply_best=mock_apply,
+            confirm=MockConfirm,
+            live_ui=MockLiveUI.return_value,
+            plain_ui=MockPlainUI.return_value,
+        )
+
+
+def _loop_kwargs(patched) -> dict:
+    """Pull the kwargs ``run_optimization_loop`` was called with."""
+    return patched.loop.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Step resolution helper: _resolve_step_to_node_id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_step_to_node_id_returns_first_node():
+    fake_client = MagicMock()
+    fake_client.list_nodes.return_value = {"nodes": [{"node_id": "node-uuid-7"}]}
+
+    result = derive._resolve_step_to_node_id(fake_client, "run-id", step=7)
+
+    assert result == "node-uuid-7"
+    # include_code=False is a deliberate optimisation — the code blob is
+    # never needed here, and dropping it saves backend work.
+    fake_client.list_nodes.assert_called_once_with("run-id", step=7, include_code=False)
+
+
+def test_resolve_step_to_node_id_raises_derive_error_when_no_node():
+    fake_client = MagicMock()
+    fake_client.list_nodes.return_value = {"nodes": []}
+
+    with pytest.raises(derive.DeriveError, match="No node found at step 99"):
+        derive._resolve_step_to_node_id(fake_client, "run-id", step=99)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end --from-step wiring through the handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "from_step, expected_derive_from, expects_lookup",
+    [
+        # Both naming conventions for both "best" keywords (the alias dict's reason for being).
+        ("best", "lineage_best", False),
+        ("lineage-best", "lineage_best", False),
+        ("lineage_best", "lineage_best", False),
+        ("run-best", "run_best", False),
+        ("run_best", "run_best", False),
+        # Integer step numbers trigger a node lookup. Negatives parse fine — the
+        # backend is responsible for rejecting nonsense step numbers.
+        ("0", "node-at-step", True),
+        ("3", "node-at-step", True),
+        ("-3", "node-at-step", True),
+        # Anything else passes through as a presumed node UUID; the backend 404s if bogus.
+        ("550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440000", False),
+        ("abc-def", "abc-def", False),
+        ("1.5", "1.5", False),  # float-shaped: not an int
+        ("", "", False),  # empty string passes through; backend will 404
+    ],
+    ids=[
+        "lineage_best-bare",
+        "lineage_best-hyphen",
+        "lineage_best-underscore",
+        "run_best-hyphen",
+        "run_best-underscore",
+        "step-zero",
+        "step-positive",
+        "step-negative",
+        "node-uuid",
+        "node-arbitrary",
+        "node-float-shaped",
+        "node-empty-string",
+    ],
+)
+def test_from_step_wiring(patched, from_step, expected_derive_from, expects_lookup):
+    """Each form of --from-step ends up calling derive_run with the right
+    derive_from value, and only the integer forms trigger a list_nodes lookup."""
+    patched.client.list_nodes.return_value = {"nodes": [{"node_id": "node-at-step"}]}
+
+    _call_handle(from_step=from_step)
+
+    assert patched.client.derive_run.call_args.kwargs["derive_from"] == expected_derive_from
+    if expects_lookup:
+        patched.client.list_nodes.assert_called_once()
+    else:
+        patched.client.list_nodes.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Loop configuration plumbing — values flow from response into the loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "loop_kwarg, expected",
+    [
+        ("eval_command", "python test.py"),
+        ("save_logs", True),
+        ("eval_timeout", 600),
+    ],
+)
+def test_loop_config_inherited_from_response(patched, loop_kwarg, expected):
+    """The loop receives its config from the derive response, not from
+    defaults or a follow-up GET."""
+    _call_handle()
+    assert _loop_kwargs(patched)[loop_kwarg] == expected
+
+
+def test_eval_timeout_none_passes_through(patched):
+    """eval_timeout is genuinely Optional[int] — None must not be coerced."""
+    patched.client.derive_run.return_value = _fake_derive_response(eval_timeout=None)
+    _call_handle()
+    assert _loop_kwargs(patched)["eval_timeout"] is None
+
+
+def test_log_dir_inherited_from_response_into_artifacts(patched):
+    """log_dir doesn't go to the loop directly — it goes to RunArtifacts."""
+    _call_handle()
+    patched.artifacts.assert_called_once()
+    assert patched.artifacts.call_args.kwargs["log_dir"] == ".weco-runs"
+
+
+def test_additional_instructions_flow_through_to_derive_run(patched):
+    """The (resolved) --additional-instructions value reaches the backend.
+    Locks in the rename from the older `direction` field name."""
+    _call_handle(additional_instructions="focus on memory efficiency")
+    assert (
+        patched.client.derive_run.call_args.kwargs["additional_instructions"]
+        == "focus on memory efficiency"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-code originals: file restoration baseline
+# ---------------------------------------------------------------------------
+
+
+def test_originals_use_inherited_source_when_local_files_missing(patched, tmp_path, monkeypatch):
+    """If a file doesn't exist locally, the originals fed to the loop must
+    come from the inherited baseline — NEVER the candidate, which would
+    pollute the working directory with generated code on every eval cycle."""
+    monkeypatch.chdir(tmp_path)  # empty directory: no local files
+    patched.client.derive_run.return_value = _fake_derive_response(
+        source_code={"main.py": "INHERITED"},
+        candidate_code={"main.py": "CANDIDATE"},
+    )
+
+    _call_handle()
+
+    source_code = _loop_kwargs(patched)["source_code"]
+    assert source_code == {"main.py": "INHERITED"}
+
+
+def test_originals_prefer_local_files_when_present(patched, tmp_path, monkeypatch):
+    """When a file exists locally, prefer it over the inherited baseline —
+    the user may have made local edits since the parent run."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "main.py").write_text("LOCAL_EDITED")
+    patched.client.derive_run.return_value = _fake_derive_response(
+        source_code={"main.py": "INHERITED"}
+    )
+
+    _call_handle()
+
+    assert _loop_kwargs(patched)["source_code"] == {"main.py": "LOCAL_EDITED"}
+
+
+# ---------------------------------------------------------------------------
+# UI dispatch: handler picks the right UI and routes derived_from via on_init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "output_mode, expected_ui, other_ui",
+    [("plain", "plain_ui", "live_ui"), ("rich", "live_ui", "plain_ui")],
+)
+def test_handler_picks_ui_for_output_mode(patched, output_mode, expected_ui, other_ui):
+    """Plain mode constructs PlainOptimizationUI, rich mode constructs
+    LiveOptimizationUI. Each gets exactly one on_init call."""
+    _call_handle(output_mode=output_mode)
+    getattr(patched, expected_ui).on_init.assert_called_once()
+    getattr(patched, other_ui).on_init.assert_not_called()
+
+
+def test_on_init_receives_derived_from_payload(patched):
+    """The parent reference flows through on_init's payload unchanged — not
+    via a side-channel print or constructor argument.
+
+    This is a *flow* test, not a value test: the assertion compares against
+    the same fixture constant (``_FAKE_DERIVED_FROM``) deliberately, to
+    verify pass-through of whatever the response contained. The specific
+    field values are an implementation detail of the fixture.
+    """
+    _call_handle()
+    assert patched.plain_ui.on_init.call_args.kwargs["derived_from"] == _FAKE_DERIVED_FROM
+
+
+# ---------------------------------------------------------------------------
+# Exit code dispatch: handler return value reflects loop result
+# ---------------------------------------------------------------------------
+
+
+def test_handler_returns_false_when_loop_fails(patched):
+    """Failed loop must propagate as ``False`` — the dispatcher relies on
+    this to set the process exit code. Loop *success* is covered implicitly
+    by every other test in this file (the default fixture exercises it)."""
+    patched.loop.return_value = OptimizationResult(
+        success=False, final_step=3, status="error", reason="submit_failed"
+    )
+    assert _call_handle() is False
+
+
+def test_handler_aborts_when_user_cancels_unchanged_files_prompt(patched):
+    """Rich mode prompts the user to confirm working-directory state. If
+    they say no, the handler aborts before starting the loop and returns
+    False without ever calling run_optimization_loop.
+
+    Verifies both that the prompt fired (so a future refactor that drops
+    the prompt entirely fails this test) and that the abort happens.
+    """
+    patched.confirm.ask.return_value = False
+    assert _call_handle(output_mode="rich") is False
+    patched.confirm.ask.assert_called_once()
+    patched.loop.assert_not_called()
+
+
+def test_plain_mode_skips_unchanged_files_prompt(patched):
+    """Agents in plain mode never see the prompt — Confirm.ask is never
+    called. This is the positive form of the cancellation test above."""
+    _call_handle(output_mode="plain")
+    patched.confirm.ask.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Apply-best lifecycle: only after a successful loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "loop_success, expect_apply_called",
+    [(True, True), (False, False)],
+    ids=["success-applies-best", "failure-skips-apply"],
+)
+def test_apply_best_only_after_successful_loop(patched, loop_success, expect_apply_called):
+    patched.loop.return_value = OptimizationResult(
+        success=loop_success,
+        final_step=2,
+        status="completed" if loop_success else "error",
+        reason="completed_successfully" if loop_success else "submit_failed",
+    )
+    _call_handle()
+    if expect_apply_called:
+        patched.apply_best.assert_called_once()
+    else:
+        patched.apply_best.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Error handling: HTTPError, network errors, DeriveError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "make_exception",
+    [
+        # Factories defer construction to test-run time so each parametrize
+        # case gets a fresh exception/mock instance — avoiding any chance of
+        # cross-test pollution from a shared MagicMock.
+        lambda: requests.exceptions.HTTPError(response=MagicMock(status_code=400, text="bad request")),
+        lambda: requests.exceptions.ConnectionError("net down"),
+    ],
+    ids=["http-error", "network-error"],
+)
+def test_api_errors_exit_cleanly_with_code_1(patched, make_exception):
+    """Both HTTP errors and network errors land in distinct except branches
+    in the handler — neither should crash inside an exception handler that
+    assumes the wrong shape (e.g. AttributeError on ``e.response``)."""
+    patched.client.derive_run.side_effect = make_exception()
+
+    with pytest.raises(SystemExit) as exc:
+        _call_handle(output_mode="rich")
+    assert exc.value.code == 1
+
+
+@pytest.mark.parametrize(
+    "output_mode, expect_json_in_stderr",
+    [("plain", True), ("rich", False)],
+    ids=["plain", "rich"],
+)
+def test_derive_error_routed_through_correct_channel(patched, capsys, output_mode, expect_json_in_stderr):
+    """A DeriveError reaches the user via stderr+JSON in plain mode and
+    styled console output in rich mode. Plain mode in particular must never
+    pollute stdout — that channel is reserved for normal output that
+    pipelines (jq, NDJSON consumers) might be parsing.
+
+    Asserts on the *structure* of the error envelope, not the exact wording
+    of the error message — wording is allowed to evolve without breaking
+    this test.
+    """
+    patched.client.list_nodes.return_value = {"nodes": []}
+
+    with pytest.raises(SystemExit) as exc:
+        _call_handle(output_mode=output_mode, from_step="42")
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+
+    if expect_json_in_stderr:
+        # Plain mode: stdout is clean, stderr contains a parseable JSON
+        # error envelope with a non-empty message under the "error" key.
+        assert captured.out == ""
+        payload = json.loads(captured.err.strip())
+        assert "error" in payload
+        assert payload["error"]  # non-empty
+    else:
+        # Rich mode: error is rendered through console.print as styled text.
+        # We don't pin a specific channel — rich is for humans, not pipes —
+        # but neither stdout nor stderr should contain a raw JSON object.
+        assert "{" not in captured.out
+        assert "{" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# API call discipline: derive needs exactly one round-trip to /derive
+# ---------------------------------------------------------------------------
+
+
+def test_handler_makes_one_derive_call_and_no_get_run_status(patched):
+    """The pre-fix handler did a follow-up GET /runs/{id} to fetch loop
+    config. After the response was enriched with that config, that second
+    call is gone. This test guards against re-introducing it."""
+    _call_handle()
+    patched.client.derive_run.assert_called_once()
+    patched.client.get_run_status.assert_not_called()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -50,3 +50,145 @@ def test_plain_optimization_ui_best_respects_minimize_goal():
 
     assert any("best so far: 1.5" in line for line in lines)
     assert any("Best metric value: 1.5" in line for line in lines)
+
+
+def _make_plain_ui_with_capture() -> tuple[PlainOptimizationUI, list[str]]:
+    """Construct a PlainOptimizationUI that records output to a list instead of stdout."""
+    ui = PlainOptimizationUI(
+        run_id="run-1",
+        run_name="demo",
+        total_steps=5,
+        dashboard_url="https://example.com",
+        model="gpt-4",
+        metric_name="accuracy",
+    )
+    lines: list[str] = []
+    ui._print = lines.append
+    return ui, lines
+
+
+def test_plain_ui_on_init_prints_header():
+    """on_init prints the run banner exactly once. (Header used to be printed
+    by __enter__; the move to on_init keeps the same observable behavior for
+    non-derived runs.)"""
+    ui, lines = _make_plain_ui_with_capture()
+
+    ui.on_init()
+
+    output = "\n".join(lines)
+    assert "WECO OPTIMIZATION RUN" in output
+    assert "Run ID: run-1" in output
+    assert "Run Name: demo" in output
+    assert "Dashboard: https://example.com" in output
+    assert "Model: gpt-4" in output
+    assert "Metric: accuracy" in output
+    assert "Total Steps: 5" in output
+    # Non-derived run: no "Derived from" line
+    assert not any("Derived from" in line for line in lines)
+
+
+def test_plain_ui_on_init_includes_derived_from_line():
+    ui, lines = _make_plain_ui_with_capture()
+
+    ui.on_init(derived_from={
+        "run_id": "parent-uuid",
+        "node_id": "node-uuid",
+        "step": 7,
+        "metric_value": 0.842,
+    })
+
+    derived_lines = [line for line in lines if "Derived from" in line]
+    assert len(derived_lines) == 1
+    assert "parent-uuid" in derived_lines[0]
+    assert "step 7" in derived_lines[0]
+    assert "0.842" in derived_lines[0]
+
+
+def test_plain_ui_on_init_handles_derived_from_without_metric():
+    """A node with no metric_value (e.g., still pending eval) shouldn't crash
+    the header rendering."""
+    ui, lines = _make_plain_ui_with_capture()
+
+    ui.on_init(derived_from={
+        "run_id": "parent-uuid",
+        "node_id": "node-uuid",
+        "step": 0,
+        "metric_value": None,
+    })
+
+    derived_lines = [line for line in lines if "Derived from" in line]
+    assert len(derived_lines) == 1
+    assert "parent-uuid" in derived_lines[0]
+    assert "step 0" in derived_lines[0]
+    # No "(metric: ...)" suffix when metric_value is None. Specific to the
+    # suffix's literal form so the assertion is robust to metric_name values
+    # that happen to contain the substring "metric".
+    assert "(metric:" not in derived_lines[0]
+
+
+def test_plain_ui_enter_no_longer_prints_header():
+    """Header printing must happen via on_init now, not __enter__. This guards
+    against accidentally re-introducing the auto-print and double-printing the
+    header."""
+    ui, lines = _make_plain_ui_with_capture()
+
+    with ui:
+        pass
+
+    assert lines == []
+
+
+def test_live_ui_on_init_renders_derived_from_row():
+    """The Live panel grid gains a "From" row when derived_from is set."""
+    ui = LiveOptimizationUI(
+        console=Console(force_terminal=False, color_system=None),
+        run_id="run-1",
+        run_name="demo",
+        total_steps=3,
+        dashboard_url="https://example.com",
+        metric_name="accuracy",
+    )
+
+    ui.on_init(derived_from={
+        "run_id": "parent-uuid",
+        "node_id": "node-uuid",
+        "step": 4,
+        "metric_value": 0.91,
+    })
+
+    text = _render_to_text(ui._render())
+    assert "parent-uuid" in text
+    assert "step 4" in text
+    assert "0.91" in text
+
+
+def test_live_ui_on_init_without_derived_from_does_not_render_from_row():
+    """Negative cousin to test_live_ui_on_init_renders_derived_from_row.
+
+    Renders the same UI both with and without ``derived_from`` and asserts
+    the parent reference (the marker added by the "From" row) appears only
+    in the derived render. Comparing the two renders directly avoids
+    fragile substring checks against unrelated panel chrome.
+    """
+
+    def render(derived_from):
+        ui = LiveOptimizationUI(
+            console=Console(force_terminal=False, color_system=None),
+            run_id="run-1",
+            run_name="demo",
+            total_steps=3,
+            dashboard_url="https://example.com",
+        )
+        ui.on_init(derived_from=derived_from)
+        return _render_to_text(ui._render())
+
+    derived_text = render({"run_id": "parent-uuid", "node_id": "n", "step": 4, "metric_value": 0.91})
+    plain_text = render(None)
+
+    # The parent reference is added only by the "From" row, so its presence
+    # in one render and absence in the other proves the row is conditional.
+    assert "parent-uuid" in derived_text
+    assert "parent-uuid" not in plain_text
+    # Belt and braces: the row label itself only appears in the derived
+    # render (no other panel label contains "From" as a substring).
+    assert "From" not in plain_text

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -90,12 +90,7 @@ def test_plain_ui_on_init_prints_header():
 def test_plain_ui_on_init_includes_derived_from_line():
     ui, lines = _make_plain_ui_with_capture()
 
-    ui.on_init(derived_from={
-        "run_id": "parent-uuid",
-        "node_id": "node-uuid",
-        "step": 7,
-        "metric_value": 0.842,
-    })
+    ui.on_init(derived_from={"run_id": "parent-uuid", "node_id": "node-uuid", "step": 7, "metric_value": 0.842})
 
     derived_lines = [line for line in lines if "Derived from" in line]
     assert len(derived_lines) == 1
@@ -109,12 +104,7 @@ def test_plain_ui_on_init_handles_derived_from_without_metric():
     the header rendering."""
     ui, lines = _make_plain_ui_with_capture()
 
-    ui.on_init(derived_from={
-        "run_id": "parent-uuid",
-        "node_id": "node-uuid",
-        "step": 0,
-        "metric_value": None,
-    })
+    ui.on_init(derived_from={"run_id": "parent-uuid", "node_id": "node-uuid", "step": 0, "metric_value": None})
 
     derived_lines = [line for line in lines if "Derived from" in line]
     assert len(derived_lines) == 1
@@ -149,12 +139,7 @@ def test_live_ui_on_init_renders_derived_from_row():
         metric_name="accuracy",
     )
 
-    ui.on_init(derived_from={
-        "run_id": "parent-uuid",
-        "node_id": "node-uuid",
-        "step": 4,
-        "metric_value": 0.91,
-    })
+    ui.on_init(derived_from={"run_id": "parent-uuid", "node_id": "node-uuid", "step": 4, "metric_value": 0.91})
 
     text = _render_to_text(ui._render())
     assert "parent-uuid" in text

--- a/weco/cli.py
+++ b/weco/cli.py
@@ -226,6 +226,30 @@ def _configure_run_subcommands(run_parser: argparse.ArgumentParser) -> None:
     revise_source.add_argument("-s", "--source", type=str, help="Path to a single source file")
     revise_source.add_argument("--sources", nargs="+", type=str, help="Paths to multiple source files")
 
+    # weco run derive <run-id>
+    p = subs.add_parser("derive", help="Create a new run derived from an existing run's step")
+    p.add_argument("run_id", type=str, help="Parent run UUID")
+    p.add_argument(
+        "--from-step", type=str, default="best", help="'best' (lineage-best, default), 'run-best', or a step number"
+    )
+    p.add_argument("-n", "--steps", type=int, default=None, help="Override step count for the derived run")
+    p.add_argument(
+        "-i",
+        "--additional-instructions",
+        type=str,
+        default=None,
+        help="Steering instructions for the new run (inline text or path to a file). "
+        "If omitted, the parent run's instructions are inherited.",
+    )
+    p.add_argument("--api-key", nargs="+", type=str, default=None, help="API keys in provider=key format")
+    p.add_argument(
+        "--output",
+        type=str,
+        choices=["rich", "plain"],
+        default="rich",
+        help="Output mode: 'rich' for interactive UI, 'plain' for machine-readable output",
+    )
+
     # weco run submit <run-id> --node <id>
     p = subs.add_parser("submit", help="Submit a pending node for evaluation (review mode)")
     p.add_argument("run_id", type=str, help="Run UUID")
@@ -350,7 +374,7 @@ Supported provider names: {supported_providers}.
 
 def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
     """Dispatch ``weco run <subcommand>`` to the appropriate handler."""
-    from .commands.run import status, results, show, diff, stop, instruct, review, revise, submit
+    from .commands.run import status, results, show, diff, stop, instruct, review, revise, submit, derive
 
     def _collect_source_paths() -> list[str] | None:
         if getattr(args, "sources", None):
@@ -371,6 +395,15 @@ def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
         ),
         "show": lambda: show.handle(run_id=args.run_id, step=args.step, console=console),
         "diff": lambda: diff.handle(run_id=args.run_id, step=args.step, against=args.against, console=console),
+        "derive": lambda: derive.handle(
+            run_id=args.run_id,
+            from_step=args.from_step,
+            steps=args.steps,
+            additional_instructions=args.additional_instructions,
+            api_keys=parse_api_keys(args.api_key),
+            output_mode=args.output,
+            console=console,
+        ),
         "stop": lambda: stop.handle(run_id=args.run_id, console=console),
         "instruct": lambda: instruct.handle(run_id=args.run_id, instructions=args.instructions, console=console),
         "review": lambda: review.handle(run_id=args.run_id, console=console),
@@ -390,8 +423,10 @@ def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
     if handler is None:
         console.print(f"[bold red]Unknown run subcommand: {sub}[/]")
         sys.exit(1)
-    handler()
-    sys.exit(0)
+    # Handlers that drive an optimization loop (e.g. derive) return a bool to
+    # signal success/failure. Read-only handlers return None and exit cleanly.
+    result = handler()
+    sys.exit(0 if result is not False else 1)
 
 
 def execute_run_command(args: argparse.Namespace) -> None:
@@ -526,7 +561,7 @@ def main() -> None:
 def _main() -> None:
     """Internal main function containing the CLI logic."""
     parser = argparse.ArgumentParser(
-        description="[bold cyan]Weco CLI[/]\nEnhance your code with AI-driven optimization.",
+        description="Weco CLI\nEnhance your code with AI-driven optimization.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/weco/commands/run/derive.py
+++ b/weco/commands/run/derive.py
@@ -1,0 +1,313 @@
+"""``weco run derive <run-id>`` — create a derived run from an existing run's step."""
+
+import json
+import pathlib
+import sys
+
+import requests
+from rich.console import Console
+from rich.prompt import Confirm
+
+from ...api import report_termination
+from ...artifacts import RunArtifacts
+from ...auth import handle_authentication
+from ...core.api import WecoClient, handle_api_error
+from ...heartbeat import heartbeat
+from ...optimizer import OptimizationResult, offer_apply_best_solution, run_optimization_loop
+from ...ui import LiveOptimizationUI, PlainOptimizationUI
+from ...utils import read_additional_instructions, read_from_path
+from ... import __dashboard_url__
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class DeriveError(Exception):
+    """User-correctable error before the optimization loop starts.
+
+    Helpers raise this to describe a failure they can't recover from. The
+    handler catches it once near the top and routes the message through the
+    right channel for the active output mode.
+    """
+
+
+# ---------------------------------------------------------------------------
+# from-step resolution
+# ---------------------------------------------------------------------------
+
+
+# Aliases the CLI accepts for the two "best node" keywords. The dict is also
+# the documentation: any key here is a valid --from-step value.
+_FROM_STEP_KEYWORDS: dict[str, str] = {
+    "best": "lineage_best",
+    "lineage-best": "lineage_best",
+    "lineage_best": "lineage_best",
+    "run-best": "run_best",
+    "run_best": "run_best",
+}
+
+
+def _resolve_step_to_node_id(client: WecoClient, run_id: str, step: int) -> str:
+    """Look up the node UUID at a given step in ``run_id``.
+
+    One API call. Raises :class:`DeriveError` if no node exists at that step.
+    HTTP/network errors propagate unchanged for the caller to format.
+    """
+    response = client.list_nodes(run_id, step=step, include_code=False)
+    nodes = response.get("nodes", [])
+    if not nodes:
+        raise DeriveError(f"No node found at step {step} in run {run_id}")
+    # Backend's NodeListItem schema (api/models/legacy.py) guarantees `node_id`.
+    # Multiple nodes per step are possible in branched lineages; we take the
+    # first as a deliberate convention.
+    return nodes[0]["node_id"]
+
+
+def _resolve_derive_from(client: WecoClient, run_id: str, from_step: str) -> str:
+    """Translate the user-facing ``--from-step`` value into the backend's
+    ``derive_from`` value.
+
+    Three forms are accepted:
+
+    * a keyword from :data:`_FROM_STEP_KEYWORDS` (``best``, ``run-best``, …)
+      → returns the backend keyword (``"lineage_best"`` / ``"run_best"``)
+    * an integer step number → looks up the node at that step (one API call)
+    * anything else → presumed node UUID, passed through for the backend to
+      validate (and 404 on if bogus)
+    """
+    if from_step in _FROM_STEP_KEYWORDS:
+        return _FROM_STEP_KEYWORDS[from_step]
+    try:
+        step = int(from_step)
+    except ValueError:
+        return from_step  # presumed node UUID
+    return _resolve_step_to_node_id(client, run_id, step)
+
+
+# ---------------------------------------------------------------------------
+# Error reporting
+# ---------------------------------------------------------------------------
+
+
+def _report_error(console: Console, output_mode: str, message: str) -> None:
+    """Print an error message in the format appropriate for ``output_mode``.
+
+    Always writes to stderr — errors should never pollute stdout where
+    machine consumers (jq, NDJSON parsers) expect normal output.
+    """
+    if output_mode == "plain":
+        print(json.dumps({"error": message}), file=sys.stderr, flush=True)
+    else:
+        console.print(f"[bold red]{message}[/]")
+
+
+def _resolve_originals(inherited_source: dict[str, str]) -> dict[str, str]:
+    """Build the file-restoration baseline for the optimization loop.
+
+    Prefer the user's local files (they may have edits since the parent run);
+    fall back to the inherited baseline source from the source node — never
+    the candidate, which would pollute the working directory with generated
+    code on every eval cycle.
+    """
+    originals: dict[str, str] = {}
+    for rel_path, inherited_content in inherited_source.items():
+        fp = pathlib.Path(rel_path)
+        originals[rel_path] = read_from_path(fp=fp, is_json=False) if fp.exists() else inherited_content
+    return originals
+
+
+def _print_resume_hint(console: Console, output_mode: str, run_id: str) -> None:
+    """Tell the user how to resume an interrupted run."""
+    hint = f"To resume this run, use: weco resume {run_id}"
+    if output_mode == "plain":
+        print(f"\n{hint}\n", flush=True)
+    else:
+        console.print(f"\n[cyan]{hint}[/]\n")
+
+
+def _drive_optimization(
+    *,
+    console: Console,
+    auth_headers: dict[str, str],
+    run_info: dict,
+    artifacts: RunArtifacts,
+    originals: dict[str, str],
+    dashboard_url: str,
+    output_mode: str,
+    api_keys: dict[str, str] | None,
+) -> OptimizationResult:
+    """Run the optimization loop within heartbeat + UI contexts.
+
+    Always returns an :class:`OptimizationResult` — the loop catches its own
+    exceptions and reports failure rather than raising. Termination is
+    reported to the backend on the way out.
+    """
+    new_run_id = run_info["id"]
+    ui_kwargs = dict(
+        run_id=new_run_id,
+        run_name=run_info["name"],
+        total_steps=run_info["steps"],
+        dashboard_url=dashboard_url,
+        model=run_info["model"],
+        metric_name=run_info["metric_name"],
+        maximize=run_info["maximize"],
+    )
+    if output_mode == "plain":
+        ui_instance = PlainOptimizationUI(**ui_kwargs)
+    else:
+        ui_instance = LiveOptimizationUI(console, **ui_kwargs)
+
+    result: OptimizationResult | None = None
+    try:
+        with heartbeat(new_run_id, auth_headers), ui_instance as ui:
+            # The UI's standard run header (printed by on_init) is the single
+            # source of truth for "what run we just created". The parent
+            # reference is surfaced via the derived_from payload.
+            ui.on_init(derived_from=run_info["derived_from"])
+
+            # The backend has already created the inherited step-0 baseline
+            # and generated the step-1 candidate; the loop picks up step 1.
+            result = run_optimization_loop(
+                ui=ui,
+                run_id=new_run_id,
+                auth_headers=auth_headers,
+                source_code=originals,
+                eval_command=run_info["evaluation_command"],
+                eval_timeout=run_info["eval_timeout"],
+                artifacts=artifacts,
+                save_logs=run_info["save_logs"],
+                start_step=1,
+                api_keys=api_keys,
+            )
+        return result
+    finally:
+        if result is not None:
+            try:
+                report_termination(
+                    run_id=new_run_id,
+                    status_update=result.status,
+                    reason=result.reason,
+                    details=result.details,
+                    auth_headers=auth_headers,
+                )
+            except Exception:
+                pass
+
+
+def _run_derived_loop(
+    *,
+    console: Console,
+    auth_headers: dict[str, str],
+    run_info: dict,
+    originals: dict[str, str],
+    dashboard_url: str,
+    output_mode: str,
+    api_keys: dict[str, str] | None,
+) -> bool:
+    """Drive the optimization loop and react to its outcome.
+
+    Returns ``True`` iff the loop completed successfully.
+    """
+    new_run_id = run_info["id"]
+    artifacts = RunArtifacts(log_dir=run_info["log_dir"], run_id=new_run_id)
+
+    result = _drive_optimization(
+        console=console,
+        auth_headers=auth_headers,
+        run_info=run_info,
+        artifacts=artifacts,
+        originals=originals,
+        dashboard_url=dashboard_url,
+        output_mode=output_mode,
+        api_keys=api_keys,
+    )
+
+    if result.status == "terminated":
+        _print_resume_hint(console, output_mode, new_run_id)
+
+    if result.success:
+        offer_apply_best_solution(
+            console=console,
+            run_id=new_run_id,
+            source_code=originals,
+            artifacts=artifacts,
+            auth_headers=auth_headers,
+            apply_change=False,
+        )
+
+    return result.success
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def handle(
+    run_id: str,
+    from_step: str,
+    steps: int | None,
+    additional_instructions: str | None,
+    api_keys: dict[str, str] | None,
+    output_mode: str,
+    console: Console,
+) -> bool:
+    """Create a derived run and run the local optimization loop against it.
+
+    Returns ``True`` on successful completion, ``False`` if the loop failed,
+    was terminated, or errored out. The dispatcher uses this to set the
+    process exit code.
+    """
+    weco_api_key, auth_headers = handle_authentication(console)
+    if weco_api_key is None:
+        sys.exit(1)
+
+    client = WecoClient(auth_headers)
+    additional_instructions = read_additional_instructions(additional_instructions)
+
+    # Single try block for everything that talks to the backend before the
+    # optimization loop. Each exception type maps to a distinct user-visible
+    # error format; the loop's own errors are reported separately by the loop.
+    try:
+        derive_from = _resolve_derive_from(client, run_id, from_step)
+        response = client.derive_run(
+            run_id, derive_from=derive_from, additional_instructions=additional_instructions, steps=steps, api_keys=api_keys
+        )
+    except DeriveError as e:
+        _report_error(console, output_mode, str(e))
+        sys.exit(1)
+    except requests.exceptions.HTTPError as e:
+        if output_mode == "plain":
+            _report_error(console, output_mode, f"HTTP {e.response.status_code}: {e.response.text}")
+        else:
+            handle_api_error(e, console)
+        sys.exit(1)
+    except requests.exceptions.RequestException as e:
+        _report_error(console, output_mode, f"Network error contacting Weco API: {e}")
+        sys.exit(1)
+
+    run_info = response["run"]
+    new_run_id = run_info["id"]
+    dashboard_url = f"{__dashboard_url__}/runs/{new_run_id}"
+
+    originals = _resolve_originals(run_info["source_code"])
+
+    if output_mode != "plain" and not Confirm.ask(
+        "Have the source files in your working directory been kept consistent with "
+        "the parent run? Local edits will override the inherited baseline.",
+        default=True,
+    ):
+        console.print("[yellow]Derive cancelled. Adjust your working directory and re-run.[/]")
+        return False
+
+    return _run_derived_loop(
+        console=console,
+        auth_headers=auth_headers,
+        run_info=run_info,
+        originals=originals,
+        dashboard_url=dashboard_url,
+        output_mode=output_mode,
+        api_keys=api_keys,
+    )

--- a/weco/commands/run/status.py
+++ b/weco/commands/run/status.py
@@ -4,7 +4,7 @@ import json
 
 from rich.console import Console
 
-from .. import make_client, fetch_nodes
+from .. import make_client, fetch_nodes, fetch_run
 
 
 def handle(run_id: str, console: Console) -> None:
@@ -30,5 +30,15 @@ def handle(run_id: str, console: Console) -> None:
         "require_review": run_meta.get("require_review", False),
         "pending_nodes": pending_nodes,
     }
+
+    # Add lineage info if present (requires full run status fetch)
+    try:
+        full_status = fetch_run(client, run_id, include_history=False)
+        if full_status.get("lineage_id"):
+            output["lineage_id"] = full_status["lineage_id"]
+        if full_status.get("derived_from"):
+            output["derived_from"] = full_status["derived_from"]
+    except SystemExit:
+        pass  # Non-critical — lineage info is supplementary
 
     print(json.dumps(output, indent=2))

--- a/weco/core/api.py
+++ b/weco/core/api.py
@@ -295,6 +295,52 @@ class WecoClient:
         resp.raise_for_status()
         return resp.json()
 
+    def derive_run(
+        self,
+        run_id: str,
+        *,
+        derive_from: str = "lineage_best",
+        additional_instructions: str | None = None,
+        stop_parent: bool = True,
+        steps: int | None = None,
+        eval_timeout: int | None = None,
+        require_review: bool | None = None,
+        api_keys: dict[str, str] | None = None,
+    ) -> dict:
+        """``POST /runs/{run_id}/derive`` — create a derived run.
+
+        Raises:
+            requests.exceptions.HTTPError: On non-2xx responses.
+        """
+        body: dict[str, Any] = {
+            "derive_from": derive_from,
+            "stop_parent": stop_parent,
+            "metadata": {"client_name": "cli", "client_version": __pkg_version__},
+        }
+        if additional_instructions is not None:
+            body["additional_instructions"] = additional_instructions
+        if steps is not None:
+            body["steps"] = steps
+        if eval_timeout is not None:
+            body["eval_timeout"] = eval_timeout
+        if require_review is not None:
+            body["require_review"] = require_review
+        if api_keys:
+            body["api_keys"] = api_keys
+        resp = self._post(f"/runs/{run_id}/derive", json=body, timeout=(10, 3650))
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_lineage(self, lineage_id: str) -> dict:
+        """``GET /lineages/{lineage_id}``
+
+        Raises:
+            requests.exceptions.HTTPError: On non-2xx responses.
+        """
+        resp = self._get(f"/lineages/{lineage_id}")
+        resp.raise_for_status()
+        return resp.json()
+
     def resume_run(self, run_id: str, *, api_keys: dict[str, str] | None = None) -> dict:
         """``POST /runs/{run_id}/resume`` — resume an interrupted run.
 

--- a/weco/heartbeat.py
+++ b/weco/heartbeat.py
@@ -1,0 +1,35 @@
+"""Reusable context manager for the run heartbeat thread.
+
+Wraps :class:`weco.optimizer.HeartbeatSender` so callers can write::
+
+    with heartbeat(run_id, auth_headers):
+        ...
+
+instead of repeating the ``Event() / start() / try / finally / set / join``
+boilerplate. The thread is started on entry and stopped (with a bounded
+join) on exit, even if the body raises.
+"""
+
+import threading
+from contextlib import contextmanager
+
+from .optimizer import HeartbeatSender
+
+
+# How long to wait for the heartbeat thread to exit cleanly on shutdown.
+# The thread is a daemon, so this is purely a courtesy join — exceeding it
+# is harmless.
+HEARTBEAT_SHUTDOWN_TIMEOUT_S = 2
+
+
+@contextmanager
+def heartbeat(run_id: str, auth_headers: dict[str, str]):
+    """Run a heartbeat thread for the lifetime of the ``with`` block."""
+    stop_event = threading.Event()
+    sender = HeartbeatSender(run_id, auth_headers, stop_event)
+    sender.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        sender.join(timeout=HEARTBEAT_SHUTDOWN_TIMEOUT_S)

--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -71,7 +71,7 @@ class HeartbeatSender(threading.Thread):
             traceback.print_exc(file=sys.stderr)
 
 
-def _run_optimization_loop(
+def run_optimization_loop(
     ui: OptimizationUI,
     run_id: str,
     auth_headers: dict,
@@ -242,7 +242,7 @@ def _run_optimization_loop(
         return OptimizationResult(success=False, final_step=step, status="error", reason="unknown", details=str(e))
 
 
-def _offer_apply_best_solution(
+def offer_apply_best_solution(
     console: Console,
     run_id: str,
     source_code: dict[str, str],
@@ -446,11 +446,12 @@ def resume_optimization(
             )
 
         with ui_instance as ui:
+            ui.on_init()
             # Populate UI with best solution from previous run if available
             if best_metric_value is not None and best_step is not None:
                 ui.on_metric(best_step, best_metric_value)
 
-            result = _run_optimization_loop(
+            result = run_optimization_loop(
                 ui=ui,
                 run_id=run_id,
                 auth_headers=auth_headers,
@@ -477,7 +478,7 @@ def resume_optimization(
                 console.print(f"\n[cyan]To resume this run, use:[/] [bold]weco resume {run_id}[/]\n")
 
         # Offer to apply best solution
-        _offer_apply_best_solution(
+        offer_apply_best_solution(
             console=console,
             run_id=run_id,
             source_code=source_code,
@@ -636,7 +637,8 @@ def optimize(
             )
 
         with ui_instance as ui:
-            result = _run_optimization_loop(
+            ui.on_init()
+            result = run_optimization_loop(
                 ui=ui,
                 run_id=run_id,
                 auth_headers=auth_headers,
@@ -663,7 +665,7 @@ def optimize(
                 console.print(f"\n[cyan]To resume this run, use:[/] [bold]weco resume {run_id}[/]\n")
 
         # Offer to apply best solution
-        _offer_apply_best_solution(
+        offer_apply_best_solution(
             console=console,
             run_id=run_id,
             source_code=source_code,

--- a/weco/ui/__init__.py
+++ b/weco/ui/__init__.py
@@ -1,0 +1,19 @@
+"""Optimization loop UI components.
+
+This package contains the ``OptimizationUI`` Protocol and its two
+implementations:
+
+* :class:`LiveOptimizationUI` — Rich Live panel for interactive terminals
+* :class:`PlainOptimizationUI` — bracket-tagged text for LLM agents and
+  machine consumers
+
+The Protocol and shared state live in ``base``; each implementation has its
+own submodule. Import everything from ``weco.ui`` directly — the symbols are
+re-exported here for backward compatibility.
+"""
+
+from .base import OptimizationUI, UIState
+from .live import LiveOptimizationUI
+from .plain import PlainOptimizationUI
+
+__all__ = ["OptimizationUI", "UIState", "LiveOptimizationUI", "PlainOptimizationUI"]

--- a/weco/ui/base.py
+++ b/weco/ui/base.py
@@ -1,0 +1,74 @@
+"""Shared types: the ``OptimizationUI`` Protocol and the ``UIState`` dataclass."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Protocol
+
+
+class OptimizationUI(Protocol):
+    """Protocol for optimization UI event handlers."""
+
+    def on_init(self, derived_from: dict | None = None) -> None:
+        """Called once after entering the UI context, before any loop events.
+
+        Implementations display the run header / panel here. Optionally accepts
+        a ``derived_from`` dict (with ``run_id``, ``node_id``, ``step``,
+        ``metric_value``) for runs created via ``weco run derive``.
+        """
+        ...
+
+    def on_polling(self, step: int) -> None:
+        """Called when polling for execution tasks."""
+        ...
+
+    def on_task_claimed(self, task_id: str, plan: Optional[str]) -> None:
+        """Called when a task is successfully claimed."""
+        ...
+
+    def on_executing(self, step: int) -> None:
+        """Called when starting to execute code."""
+        ...
+
+    def on_output(self, output: str, max_preview: int = 200) -> None:
+        """Called with execution output."""
+        ...
+
+    def on_submitting(self) -> None:
+        """Called when submitting result to backend."""
+        ...
+
+    def on_metric(self, step: int, value: float) -> None:
+        """Called when a metric value is received."""
+        ...
+
+    def on_complete(self, total_steps: int) -> None:
+        """Called when optimization completes successfully."""
+        ...
+
+    def on_stop_requested(self) -> None:
+        """Called when a stop request is received from dashboard."""
+        ...
+
+    def on_interrupted(self) -> None:
+        """Called when interrupted by user (Ctrl+C)."""
+        ...
+
+    def on_warning(self, message: str) -> None:
+        """Called for non-fatal warnings."""
+        ...
+
+    def on_error(self, message: str) -> None:
+        """Called for errors."""
+        ...
+
+
+@dataclass
+class UIState:
+    """Reactive state for the live optimization UI."""
+
+    step: int = 0
+    total_steps: int = 0
+    status: str = "initializing"  # polling, executing, submitting, complete, stopped, error
+    plan_preview: str = ""
+    output_preview: str = ""
+    metrics: List[tuple] = field(default_factory=list)  # (step, value)
+    error: Optional[str] = None

--- a/weco/ui/live.py
+++ b/weco/ui/live.py
@@ -1,13 +1,7 @@
-"""
-Optimization loop UI components.
-
-This module contains the UI protocol and implementations for displaying
-optimization progress in the CLI.
-"""
+"""Rich Live panel implementation of ``OptimizationUI``."""
 
 import time
-from dataclasses import dataclass, field
-from typing import List, Optional, Protocol
+from typing import List, Optional
 
 from rich.console import Console, Group
 from rich.live import Live
@@ -15,66 +9,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-
-class OptimizationUI(Protocol):
-    """Protocol for optimization UI event handlers."""
-
-    def on_polling(self, step: int) -> None:
-        """Called when polling for execution tasks."""
-        ...
-
-    def on_task_claimed(self, task_id: str, plan: Optional[str]) -> None:
-        """Called when a task is successfully claimed."""
-        ...
-
-    def on_executing(self, step: int) -> None:
-        """Called when starting to execute code."""
-        ...
-
-    def on_output(self, output: str, max_preview: int = 200) -> None:
-        """Called with execution output."""
-        ...
-
-    def on_submitting(self) -> None:
-        """Called when submitting result to backend."""
-        ...
-
-    def on_metric(self, step: int, value: float) -> None:
-        """Called when a metric value is received."""
-        ...
-
-    def on_complete(self, total_steps: int) -> None:
-        """Called when optimization completes successfully."""
-        ...
-
-    def on_stop_requested(self) -> None:
-        """Called when a stop request is received from dashboard."""
-        ...
-
-    def on_interrupted(self) -> None:
-        """Called when interrupted by user (Ctrl+C)."""
-        ...
-
-    def on_warning(self, message: str) -> None:
-        """Called for non-fatal warnings."""
-        ...
-
-    def on_error(self, message: str) -> None:
-        """Called for errors."""
-        ...
-
-
-@dataclass
-class UIState:
-    """Reactive state for the live optimization UI."""
-
-    step: int = 0
-    total_steps: int = 0
-    status: str = "initializing"  # polling, executing, submitting, complete, stopped, error
-    plan_preview: str = ""
-    output_preview: str = ""
-    metrics: List[tuple] = field(default_factory=list)  # (step, value)
-    error: Optional[str] = None
+from .base import UIState
 
 
 class LiveOptimizationUI:
@@ -124,6 +59,7 @@ class LiveOptimizationUI:
         self.maximize = maximize
         self.state = UIState(total_steps=total_steps)
         self._live: Optional[Live] = None
+        self._derived_from: Optional[dict] = None  # populated by on_init for derived runs
 
     def _sparkline(self, values: List[float], max_width: int) -> str:
         """
@@ -170,6 +106,10 @@ class LiveOptimizationUI:
             grid.add_row("Model", f"[cyan]{self.model}[/]")
         if self.metric_name:
             grid.add_row("Metric", f"[magenta]{self.metric_name}[/]")
+        if self._derived_from:
+            df = self._derived_from
+            metric_suffix = f" [dim](metric: {df['metric_value']:.6g})[/]" if df.get("metric_value") is not None else ""
+            grid.add_row("From", f"[yellow]{df['run_id']}[/] [dim]@ step {df['step']}[/]{metric_suffix}")
         grid.add_row("", "")
 
         # Progress (always shown)
@@ -267,6 +207,12 @@ class LiveOptimizationUI:
             self._live = None
 
     # --- OptimizationUI Protocol Implementation ---
+    def on_init(self, derived_from: Optional[dict] = None) -> None:
+        """Display the run header. For derived runs, the parent reference is
+        included as a "From" row in the panel."""
+        self._derived_from = derived_from
+        self._update()
+
     def on_polling(self, step: int) -> None:
         self.state.step = step
         self.state.status = "polling"
@@ -315,119 +261,3 @@ class LiveOptimizationUI:
         self.state.error = message
         self.state.status = "error"
         self._update()
-
-
-class PlainOptimizationUI:
-    """
-    Plain text implementation of OptimizationUI for machine-readable output.
-
-    Designed to be consumed by LLM agents - outputs structured, parseable text
-    without Rich formatting, ANSI codes, or interactive elements.
-    Includes full execution output for agent consumption.
-    """
-
-    def __init__(
-        self,
-        run_id: str,
-        run_name: str,
-        total_steps: int,
-        dashboard_url: str,
-        model: str = "",
-        metric_name: str = "",
-        maximize: bool = True,
-    ):
-        self.run_id = run_id
-        self.run_name = run_name
-        self.total_steps = total_steps
-        self.dashboard_url = dashboard_url
-        self.model = model
-        self.metric_name = metric_name
-        self.maximize = maximize
-        self.current_step = 0
-        self.metrics: List[tuple] = []  # (step, value)
-        self._header_printed = False
-
-    def _print(self, message: str) -> None:
-        """Print a message to stdout with flush for immediate output."""
-        print(message, flush=True)
-
-    def _print_header(self) -> None:
-        """Print run header info once at start."""
-        if self._header_printed:
-            return
-        self._header_printed = True
-        self._print("=" * 60)
-        self._print("WECO OPTIMIZATION RUN")
-        self._print("=" * 60)
-        self._print(f"Run ID: {self.run_id}")
-        self._print(f"Run Name: {self.run_name}")
-        self._print(f"Dashboard: {self.dashboard_url}")
-        if self.model:
-            self._print(f"Model: {self.model}")
-        if self.metric_name:
-            self._print(f"Metric: {self.metric_name}")
-        self._print(f"Total Steps: {self.total_steps}")
-        self._print("=" * 60)
-        self._print("")
-
-    # --- Context manager (no-op for plain output) ---
-    def __enter__(self) -> "PlainOptimizationUI":
-        self._print_header()
-        return self
-
-    def __exit__(self, *args) -> None:
-        pass
-
-    # --- OptimizationUI Protocol Implementation ---
-    def on_polling(self, step: int) -> None:
-        self.current_step = step
-        self._print(f"[STEP {step}/{self.total_steps}] Polling for task...")
-
-    def on_task_claimed(self, task_id: str, plan: Optional[str]) -> None:
-        self._print(f"[TASK CLAIMED] {task_id}")
-        if plan:
-            self._print(f"[PLAN] {plan}")
-
-    def on_executing(self, step: int) -> None:
-        self.current_step = step
-        self._print(f"[STEP {step}/{self.total_steps}] Executing code...")
-
-    def on_output(self, output: str, max_preview: int = 200) -> None:
-        # For plain mode, output the full execution result for LLM consumption
-        self._print("[EXECUTION OUTPUT START]")
-        self._print(output)
-        self._print("[EXECUTION OUTPUT END]")
-
-    def on_submitting(self) -> None:
-        self._print("[SUBMITTING] Sending result to backend...")
-
-    def on_metric(self, step: int, value: float) -> None:
-        self.metrics.append((step, value))
-        best_fn = max if self.maximize else min
-        best = best_fn(m[1] for m in self.metrics) if self.metrics else value
-        self._print(f"[METRIC] Step {step}: {value:.6g} (best so far: {best:.6g})")
-
-    def on_complete(self, total_steps: int) -> None:
-        self._print("")
-        self._print("=" * 60)
-        self._print("[COMPLETE] Optimization finished successfully")
-        self._print(f"Total steps completed: {total_steps}")
-        if self.metrics:
-            values = [m[1] for m in self.metrics]
-            best_fn = max if self.maximize else min
-            self._print(f"Best metric value: {best_fn(values):.6g}")
-        self._print("=" * 60)
-
-    def on_stop_requested(self) -> None:
-        self._print("")
-        self._print("[STOPPED] Run stopped by user request")
-
-    def on_interrupted(self) -> None:
-        self._print("")
-        self._print("[INTERRUPTED] Run interrupted (Ctrl+C)")
-
-    def on_warning(self, message: str) -> None:
-        self._print(f"[WARNING] {message}")
-
-    def on_error(self, message: str) -> None:
-        self._print(f"[ERROR] {message}")

--- a/weco/ui/plain.py
+++ b/weco/ui/plain.py
@@ -1,0 +1,130 @@
+"""Plain-text implementation of ``OptimizationUI`` for LLM agents and machine consumers."""
+
+from typing import List, Optional
+
+
+class PlainOptimizationUI:
+    """
+    Plain text implementation of OptimizationUI for machine-readable output.
+
+    Designed to be consumed by LLM agents - outputs structured, parseable text
+    without Rich formatting, ANSI codes, or interactive elements.
+    Includes full execution output for agent consumption.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        run_name: str,
+        total_steps: int,
+        dashboard_url: str,
+        model: str = "",
+        metric_name: str = "",
+        maximize: bool = True,
+    ):
+        self.run_id = run_id
+        self.run_name = run_name
+        self.total_steps = total_steps
+        self.dashboard_url = dashboard_url
+        self.model = model
+        self.metric_name = metric_name
+        self.maximize = maximize
+        self.current_step = 0
+        self.metrics: List[tuple] = []  # (step, value)
+        self._header_printed = False
+        self._derived_from: Optional[dict] = None  # populated by on_init for derived runs
+
+    def _print(self, message: str) -> None:
+        """Print a message to stdout with flush for immediate output."""
+        print(message, flush=True)
+
+    def _print_header(self) -> None:
+        """Print run header info once at start."""
+        if self._header_printed:
+            return
+        self._header_printed = True
+        self._print("=" * 60)
+        self._print("WECO OPTIMIZATION RUN")
+        self._print("=" * 60)
+        self._print(f"Run ID: {self.run_id}")
+        self._print(f"Run Name: {self.run_name}")
+        self._print(f"Dashboard: {self.dashboard_url}")
+        if self.model:
+            self._print(f"Model: {self.model}")
+        if self.metric_name:
+            self._print(f"Metric: {self.metric_name}")
+        self._print(f"Total Steps: {self.total_steps}")
+        if self._derived_from:
+            df = self._derived_from
+            metric = df.get("metric_value")
+            metric_suffix = f" (metric: {metric:.6g})" if metric is not None else ""
+            self._print(f"Derived from: {df['run_id']} @ step {df['step']}{metric_suffix}")
+        self._print("=" * 60)
+        self._print("")
+
+    # --- Context manager (header printing happens via on_init, not __enter__) ---
+    def __enter__(self) -> "PlainOptimizationUI":
+        return self
+
+    def __exit__(self, *args) -> None:
+        pass
+
+    # --- OptimizationUI Protocol Implementation ---
+    def on_init(self, derived_from: Optional[dict] = None) -> None:
+        """Print the run header. Includes a "Derived from" line when the run
+        was created via ``weco run derive``."""
+        self._derived_from = derived_from
+        self._print_header()
+
+    def on_polling(self, step: int) -> None:
+        self.current_step = step
+        self._print(f"[STEP {step}/{self.total_steps}] Polling for task...")
+
+    def on_task_claimed(self, task_id: str, plan: Optional[str]) -> None:
+        self._print(f"[TASK CLAIMED] {task_id}")
+        if plan:
+            self._print(f"[PLAN] {plan}")
+
+    def on_executing(self, step: int) -> None:
+        self.current_step = step
+        self._print(f"[STEP {step}/{self.total_steps}] Executing code...")
+
+    def on_output(self, output: str, max_preview: int = 200) -> None:
+        # For plain mode, output the full execution result for LLM consumption
+        self._print("[EXECUTION OUTPUT START]")
+        self._print(output)
+        self._print("[EXECUTION OUTPUT END]")
+
+    def on_submitting(self) -> None:
+        self._print("[SUBMITTING] Sending result to backend...")
+
+    def on_metric(self, step: int, value: float) -> None:
+        self.metrics.append((step, value))
+        best_fn = max if self.maximize else min
+        best = best_fn(m[1] for m in self.metrics) if self.metrics else value
+        self._print(f"[METRIC] Step {step}: {value:.6g} (best so far: {best:.6g})")
+
+    def on_complete(self, total_steps: int) -> None:
+        self._print("")
+        self._print("=" * 60)
+        self._print("[COMPLETE] Optimization finished successfully")
+        self._print(f"Total steps completed: {total_steps}")
+        if self.metrics:
+            values = [m[1] for m in self.metrics]
+            best_fn = max if self.maximize else min
+            self._print(f"Best metric value: {best_fn(values):.6g}")
+        self._print("=" * 60)
+
+    def on_stop_requested(self) -> None:
+        self._print("")
+        self._print("[STOPPED] Run stopped by user request")
+
+    def on_interrupted(self) -> None:
+        self._print("")
+        self._print("[INTERRUPTED] Run interrupted (Ctrl+C)")
+
+    def on_warning(self, message: str) -> None:
+        self._print(f"[WARNING] {message}")
+
+    def on_error(self, message: str) -> None:
+        self._print(f"[ERROR] {message}")


### PR DESCRIPTION
## Summary

  Adds `weco run derive <run-id>` — create a new run that branches off an existing run's step, inheriting its context and continuing optimization from there.

  ## CLI

  weco run derive  [--from-step best|run-best|] [-n STEPS]
                           [-i INSTRUCTIONS] [--api-key provider=key ...]
                           [--output rich|plain]

  - `--from-step` accepts `best` (lineage-best, default), `run-best`, or an integer step; integers resolve to a node UUID via `list_nodes` before the request.
  - `-i/--additional-instructions` takes inline text or a file path; omit to inherit the parent run's instructions.
  - `--output plain` emits bracket-tagged text for machine consumers; `rich` (default) drives the interactive panel.

  ## Implementation notes

  - New `WecoClient.derive_run` → `POST /runs/{run_id}/derive`, plus `get_lineage` for resolving derived-from metadata.
  - `weco/ui.py` split into a package: `base.py` (Protocol + `UIState`), `live.py`, `plain.py`. `OptimizationUI.on_init` now takes an optional `derived_from` dict so the header can show the parent step and metric.
  - Heartbeat loop factored into a `heartbeat(run_id, auth_headers)` context manager to remove the `Event/start/try/finally/join` boilerplate from handlers.
  - `_dispatch_run_subcommand` now honours a bool return from handlers that drive an optimization loop, so derive can exit non-zero on failure without touching read-only handlers.