### PR TITLE
optimizer: allow resume of short-completed runs

### DIFF
--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -437,14 +437,6 @@ def resume_optimization(
         console.print(f"[bold red]Error fetching run status: {e}[/]")
         return False
 
-    run_status_val = status.get("status")
-    if run_status_val not in ("error", "terminated"):
-        console.print(
-            f"[yellow]Run {run_id} cannot be resumed (status: {run_status_val}). "
-            f"Only 'error' or 'terminated' runs can be resumed.[/]"
-        )
-        return False
-
     objective = status.get("objective", {})
     metric_name = objective.get("metric_name", "metric")
     maximize = bool(objective.get("maximize", True))
@@ -454,6 +446,28 @@ def resume_optimization(
     total_steps = optimizer.get("steps", 0)
     current_step = int(status.get("current_step", 0))
     steps_remaining = int(total_steps) - current_step
+
+    run_status_val = status.get("status")
+    # Allow resume for runs prematurely marked "completed" with current_step <
+    # total_steps. This happens when a transient `Failed to submit result` on
+    # the CLI side races with a successful backend ack — backend records the
+    # result and marks the run completed, but the CLI exits with submit_failed
+    # well short of the configured step budget. Treat these as resumable so
+    # users can pick up where they left off without losing their step history.
+    short_completed = run_status_val == "completed" and steps_remaining > 0
+    if run_status_val not in ("error", "terminated") and not short_completed:
+        console.print(
+            f"[yellow]Run {run_id} cannot be resumed (status: {run_status_val}, "
+            f"current_step={current_step}/{total_steps}). "
+            f"Resumable when status in (error, terminated) or "
+            f"completed with current_step < total_steps.[/]"
+        )
+        return False
+    if short_completed:
+        console.print(
+            f"[cyan]Run is marked completed at step {current_step}/{total_steps}. "
+            f"Resuming the remaining {steps_remaining} step(s).[/]"
+        )
 
     model_name = (
         (optimizer.get("code_generator") or {}).get("model") or (optimizer.get("evaluator") or {}).get("model") or "unknown"


### PR DESCRIPTION
## Summary

Allow \`weco resume\` to recover runs that the backend marked \`completed\` short of their step budget. Previously these were stuck — the only escape was a fresh run.

## Why

A transient \`Failed to submit result\` on the CLI side can race with a successful backend ack: the backend records the result and marks the run \`completed\` (its own step counter), but the CLI exits with \`submit_failed\` well short of \`total_steps\`. Subsequent \`weco resume\` returns \`Run cannot be resumed (status: completed)\` and the user has to start over.

Discovered during a multi-day fraud-detection IEEE-CIS rerun: ~5 of 18 cells \"completed\" at 60–130 steps out of 200 because of intermittent network blips.

## Change

\`resume_optimization()\` now treats \`status='completed' AND current_step < total_steps\` (\"short-completed\") as resumable. The run is flipped back to \`running\` by \`resume_optimization_run()\` the same way it always was, and the queue loop picks up at the prepared \`start_step\`.

## Test plan

- [ ] Existing \`error\`/\`terminated\` resume paths still work (no regression).
- [ ] On a run with \`status='completed', current_step=60, steps=200\`, \`weco resume\` prompts and continues at step 60.
- [ ] On a run with \`status='completed', current_step=200, steps=200\` (truly done), resume is still rejected with the \`completed/total_steps\` message — no spurious re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)