### PR TITLE
Add gpt-5.5 family and claude-opus-4-7 to README model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,15 +285,15 @@ You can specify which LLM model to use with the `-M` or `--model` flag:
 weco run --model gpt-5 --source optimize.py [other options...]
 ```
 
-**Available models (37 total):**
+**Available models:**
 
 **OpenAI Models:**
-- GPT-5 Series: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5-codex`, `gpt-5-pro`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
+- GPT-5 Series: `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5-codex`, `gpt-5-pro`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
 - O-Series Reasoning: `o3-pro`, `o3`, `o3-mini`, `o4-mini`, `o1-pro`, `o1`
 - GPT-4 Series: `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`
 
 **Anthropic Claude (via Vertex AI):**
-- `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5`, `claude-opus-4-1`, `claude-opus-4`, `claude-sonnet-4-5`, `claude-sonnet-4`, `claude-haiku-4-5`
+- `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5`, `claude-opus-4-1`, `claude-opus-4`, `claude-sonnet-4-5`, `claude-sonnet-4`, `claude-haiku-4-5`
 
 **Google Gemini:**
 - `gemini-3.1-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`


### PR DESCRIPTION
## Summary
- Add `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.3-codex`, and `claude-opus-4-7` to the README model list
- Drop the stale "(37 total)" count — it was already off and goes stale every time we add models

Pairs with the proxy PR in `litellm-gcp-cloud-run` that adds these models to the LiteLLM config.

## Test plan
- [x] CLI hello-world example with `--model gpt-5.5` and `--model claude-opus-4-7` both work end-to-end
- [ ] README renders correctly on PyPI / GitHub