### PR TITLE
Add prompt-compression example: BANKING77 65K -> 3.2K (95.1%)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Explore runnable examples that show how to use Weco to optimize ML models, promp
   - [⚡ Triton Optimization](#-triton-optimization)
   - [🚀 CUDA Optimization](#-cuda-optimization)
   - [🧠 Prompt Engineering](#-prompt-engineering)
+  - [🗜️ Prompt Compression](#-prompt-compression)
   - [📊 Extract Line Plot — Chart to CSV](#-extract-line-plot--chart-to-csv)
   - [🛰️ Model Development — Spaceship Titanic](#️-model-development--spaceship-titanic)
 
@@ -33,6 +34,7 @@ pip install weco
 | ⚡ Triton Optimization | Speed up attention with Triton kernels | `numpy`, `torch`, `triton`, NVIDIA GPU | [README](triton/README.md) |
 | 🚀 CUDA Optimization | Generate low-level CUDA kernels for max speed | `ninja`, `numpy`, `torch`, `triton`, NVIDIA GPU, CUDA Toolkit | [README](cuda/README.md) |
 | 🧠 Prompt Engineering | Iteratively refine LLM prompts to improve accuracy | `openai`, `datasets`, OpenAI API key | [README](prompt/README.md) |
+| 🗜️ Prompt Compression | Shrink a 65K-char classifier prompt by ~95% on BANKING77 while holding accuracy | `openai`, `datasets`, OpenAI API key | [README](prompt-compression/README.md) |
 | 📊 Agentic Scaffolding | Optimize agentic scaffolding for chart-to-CSV extraction | `openai`, `huggingface_hub`, `uv`, OpenAI API key | [README](extract-line-plot/README.md) |
 | 🛰️ Spaceship Titanic | Improve a Kaggle model training pipeline | `pandas`, `numpy`, `scikit-learn`, `torch`, `xgboost`, `lightgbm`, `catboost` | [README](spaceship-titanic/README.md) |
 
@@ -128,6 +130,26 @@ weco run --source optimize.py \
      --model o4-mini \
      --additional-instructions "Improve the prompt to get better scores. Focus on clarity, specificity, and effective prompt engineering techniques."
 ```
+
+### 🗜️ Prompt Compression
+
+- **Requirements**: OpenAI API key (create [here](https://platform.openai.com/api-keys))
+- **Install Dependencies**: `pip install openai "datasets<4.0"`
+- **Run**:
+```bash
+cd examples/prompt-compression
+export OPENAI_API_KEY="your_key_here"
+python bake_optimize.py            # one-shot: writes the bloated 65,887-char baseline into optimize.py
+weco run --source optimize.py \
+     --eval-command "python eval.py" \
+     --metric metric \
+     --goal minimize \
+     --steps 50 \
+     --model claude-opus-4-7 \
+     --additional-instructions prompt_guide.md \
+     --apply-change
+```
+- **What you'll see**: Weco shrinks the BANKING77 classifier system prompt by ~95% (65,887 → ~3,200 chars) while holding accuracy at the baseline-minus-2pp threshold. See [the share link](https://weco.ai/share/XSRQdS7vfMdt9beD3KR1tlhg7By-FFIo) for the trajectory of one full run.
 
 ### 📊 Extract Line Plot — Chart to CSV
 

--- a/examples/prompt-compression/README.md
+++ b/examples/prompt-compression/README.md
@@ -1,0 +1,142 @@
+# Prompt Compression
+
+This example shows how **Weco** compresses a long, over-engineered LLM system
+prompt while keeping its classification accuracy intact. The classifier task
+is the public [PolyAI/banking77](https://huggingface.co/datasets/PolyAI/banking77)
+77-intent banking dataset; the prompt to compress is a deliberately bloated
+65,887-character system prompt that mimics real-world enterprise prompt patterns
+(verbose preamble, per-class blocks with Description / Typical phrasings /
+Disambiguation / Output sections, FAQ, worked examples).
+
+Treating character count as a cost to minimize and accuracy as a constraint to
+preserve, Weco searches the prompt space and finds dramatic compression with
+no measurable accuracy drop.
+
+> **Headline result** with `--model claude-opus-4-7` × 50 steps:
+> **65,887 → 3,229 chars (95.1% reduction)** holding accuracy at the
+> baseline-minus-2pp threshold. ([share link](https://weco.ai/share/XSRQdS7vfMdt9beD3KR1tlhg7By-FFIo))
+
+## Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/WecoAI/weco-cli.git
+   cd weco-cli/examples/prompt-compression
+   ```
+
+2. Install the CLI and dependencies:
+   ```bash
+   pip install weco openai "datasets<4.0"
+   ```
+
+3. Set your OpenAI API key (used by the classifier; Weco's optimizer LLM is
+   billed via Weco credits):
+   ```bash
+   export OPENAI_API_KEY="your_key_here"
+   ```
+
+4. Bake the bloated baseline into `optimize.py`:
+   ```bash
+   python bake_optimize.py
+   ```
+   This deterministically generates a 65,887-char `SYSTEM_PROMPT` and writes
+   `optimize.py`. Run this **once** before kicking off Weco — re-running it
+   afterwards will overwrite Weco's progress.
+
+5. (Optional) Re-measure the baseline accuracy for your environment:
+   ```bash
+   python measure_baseline.py
+   ```
+   This writes `baseline_accuracy.json`. A pre-measured value of 0.7700 (200
+   samples, seed=0, `gpt-5-mini`, `reasoning_effort=minimal`) is committed; if
+   you change the classifier model or sample size you should re-measure.
+
+## Files in this folder
+
+| File | Purpose |
+| :--- | :--- |
+| `optimize.py` | Holds the `SYSTEM_PROMPT` string and the `classify(query, model)` function. **Weco mutates only the `SYSTEM_PROMPT` string content** in the marked WECO-MUTABLE REGION. The `classify()` function and surrounding code remain intact. |
+| `eval.py` | Loads 200 BANKING77 test samples (seed=0), runs `optimize.classify` in parallel, parses the LLM output to a canonical label, and emits the three lines `accuracy:`, `chars:`, `metric:`. The composite `metric = chars` if `accuracy ≥ ACCURACY_THRESHOLD` else `chars + 10⁷` (penalty). |
+| `labels.py` | The 77 BANKING77 canonical labels in dataset-index order, plus `parse_predicted_label()` for robust label extraction from free-text LLM responses. |
+| `build_bloated_prompt.py` | Deterministically generates the 65,887-char baseline prompt. Idempotent. |
+| `bake_optimize.py` | Bakes the generated baseline into `optimize.py`. Run once at setup. |
+| `measure_baseline.py` | Measures baseline accuracy on the 200-sample slice and writes `baseline_accuracy.json`. |
+| `baseline_accuracy.json` | Frozen baseline accuracy (consumed by `eval.py` to set the threshold). |
+| `prompt_guide.md` | The `--additional-instructions` content the optimizer LLM reads. |
+
+## Run Weco
+
+```bash
+weco run --source optimize.py \
+     --eval-command "python eval.py" \
+     --metric metric \
+     --goal minimize \
+     --steps 50 \
+     --model claude-opus-4-7 \
+     --additional-instructions prompt_guide.md \
+     --apply-change
+```
+
+You'll see eval output streaming for each step, then a step summary like:
+
+```text
+[setup] loading 200 BANKING77 test samples (seed=0)
+[setup] running 200 classifications via gpt-5-mini (20 workers)
+[progress] 40/200 completed, accuracy: 0.7250, parse-rate: 1.0000, elapsed 5.7s
+...
+[progress] 200/200 completed, accuracy: 0.7700, parse-rate: 1.0000, elapsed 21.6s
+accuracy: 0.7700
+chars: 65887
+metric: 65887
+```
+
+Weco then proposes mutations to `SYSTEM_PROMPT`, re-evaluates, and pushes the
+metric (chars) down while the constraint (accuracy ≥ baseline − 2pp) holds.
+
+## What to expect
+
+In our 50-step runs the optimizer found two qualitatively different solutions:
+
+| Optimizer | best chars | reduction | acc | strategy |
+| :--- | ---: | ---: | ---: | :--- |
+| `claude-opus-4-7` | **3,229** | **95.1%** | 0.7500 | bare label list + 12 cluster disambiguation rules (`Refund: initiating=request_refund; missing=Refund_not_showing_up; …`) |
+| `gpt-5.5` | 6,828 | 89.6% | 0.7550 | one terse cue per label (`activate_my_card: activate received/new card`, ~80 chars × 77) |
+
+Both held the accuracy threshold. Opus's strategy is roughly **2× more
+compressed** at the same quality — it trusts the model to infer meaning from
+label *names* alone for most classes, only adding explicit hints for the
+clusters of confusable intents.
+
+## How it works
+
+* **Loss**: `metric = chars` when accuracy clears the threshold; else
+  `chars + 10_000_000`. Weco minimizes `metric`, so any variant that loses
+  accuracy is heavily penalized.
+* **Threshold**: `baseline_accuracy − 2pp`, loaded from
+  `baseline_accuracy.json`. The 2pp slack covers per-call sampling variance
+  on 200 samples.
+* **Eval cost**: ~$0.50–1.00 per evaluation pass at full prompt size, dropping
+  linearly as the prompt shrinks. A 50-step run is ~$5–15 for evaluation; the
+  optimizer-LLM cost is billed separately via Weco credits.
+* **Reproducibility**: the baseline prompt is generated by
+  `build_bloated_prompt.py` from a deterministic template + the 77-label list.
+  Anyone who runs `python bake_optimize.py` gets bit-identical
+  `SYSTEM_PROMPT`. The 200-sample test slice is fixed by `EVAL_SEED=0`.
+
+## A note on the baseline
+
+The 65K-char "bloated" baseline is **synthetic** — generated programmatically
+to mimic real production-style classifier prompts (operating principles,
+per-class blocks, FAQ, worked examples). PolyAI's BANKING77 dataset itself is
+real and public, but it ships only `(text, label)` pairs and predates the
+prompt-engineering era. We use the synthetic baseline so the example is fully
+public and reproducible. The compression ratios we observe (~95%) line up with
+what we've seen on real customer prompts of similar size and shape.
+
+## Next Steps
+
+* Read the [Prompt Engineering example](../prompt/README.md) for the
+  *maximize-accuracy* shape (AIME math), which complements the
+  *minimize-chars-with-accuracy-floor* shape used here.
+* See the [CLI Reference](https://docs.weco.ai/cli/cli-reference) for all
+  `weco run` options.

--- a/examples/prompt-compression/bake_optimize.py
+++ b/examples/prompt-compression/bake_optimize.py
@@ -1,0 +1,76 @@
+"""One-shot script: bakes the bloated baseline prompt into optimize.py.
+
+Run once before kicking off Weco. After this, Weco mutates optimize.py
+directly — DO NOT re-run this script mid-optimization (it will overwrite
+Weco's progress with the original bloated baseline).
+
+Usage:
+    python bake_optimize.py
+"""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from build_bloated_prompt import build_prompt  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent
+OPTIMIZE_PATH = ROOT / "optimize.py"
+
+PROMPT = build_prompt()
+escaped = PROMPT.replace('"""', '\\"\\"\\"')
+
+OPTIMIZE_BODY = f'''\
+"""BANKING77 intent classifier — the file Weco edits.
+
+Weco mutates SYSTEM_PROMPT below to compress it while preserving classification
+accuracy. The classify() function and surrounding plumbing must remain
+intact — only the SYSTEM_PROMPT string content should be modified.
+
+Baseline prompt: {len(PROMPT):,} chars across all 77 classes.
+"""
+from __future__ import annotations
+import os
+from openai import OpenAI
+
+# ---------------------------------------------------------------------------
+# WECO-MUTABLE REGION: only the SYSTEM_PROMPT string content should be edited.
+# Do not change the variable name, the assignment, or the surrounding code.
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT = """{escaped}"""
+# ---------------------------------------------------------------------------
+# END WECO-MUTABLE REGION
+# ---------------------------------------------------------------------------
+
+
+_client: OpenAI | None = None
+
+
+def _get_client() -> OpenAI:
+    global _client
+    if _client is None:
+        _client = OpenAI()
+    return _client
+
+
+def classify(query: str, model: str = "gpt-5-mini") -> str:
+    """Classify a single user query into one of the 77 BANKING77 intents.
+
+    Returns the model's raw text response. Label parsing happens in eval.py.
+    """
+    response = _get_client().chat.completions.create(
+        model=model,
+        messages=[
+            {{"role": "system", "content": SYSTEM_PROMPT}},
+            {{"role": "user", "content": query}},
+        ],
+        max_completion_tokens=256,
+        reasoning_effort="minimal",
+    )
+    return (response.choices[0].message.content or "").strip()
+'''
+
+OPTIMIZE_PATH.write_text(OPTIMIZE_BODY, encoding="utf-8")
+print(f"wrote {OPTIMIZE_PATH} ({OPTIMIZE_PATH.stat().st_size:,} bytes)")
+print(f"  SYSTEM_PROMPT: {len(PROMPT):,} chars")

--- a/examples/prompt-compression/baseline_accuracy.json
+++ b/examples/prompt-compression/baseline_accuracy.json
@@ -1,0 +1,9 @@
+{
+  "accuracy": 0.77,
+  "n_samples": 200,
+  "model": "gpt-5-mini",
+  "seed": 0,
+  "chars": 65887,
+  "parse_rate": 1.0,
+  "elapsed_seconds": 21.617523908615112
+}

--- a/examples/prompt-compression/build_bloated_prompt.py
+++ b/examples/prompt-compression/build_bloated_prompt.py
@@ -1,0 +1,413 @@
+"""Generate the deliberately-bloated baseline system prompt for BANKING77 intent
+classification. Output is the SYSTEM_PROMPT string baked into optimize.py.
+
+The prompt is designed to look like a typical over-engineered enterprise
+classifier prompt: long preamble of rules and principles, per-class blocks
+with redundant fields (Description, Typical phrasings, Disambiguation,
+Edge cases), and a long postamble of FAQs, common-mistakes, and
+worked examples. Total target: ~55,000-65,000 characters.
+
+Usage:
+    python build_bloated_prompt.py > prompt_baseline.txt
+
+The script is deterministic: given the LABEL_DESCRIPTIONS table, the same
+prompt is produced every time.
+"""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from labels import LABELS  # noqa: E402
+
+
+def humanize(label: str) -> str:
+    """Convert a snake_case label into a human-readable topic phrase."""
+    s = label.rstrip("?").replace("_", " ").lower()
+    # tidy a few label-specific oddities
+    s = s.replace(" or ", " or ").replace("pin", "PIN").replace("atm", "ATM")
+    s = s.replace("apple pay", "Apple Pay").replace("google pay", "Google Pay")
+    s = s.replace("visa", "Visa").replace("mastercard", "Mastercard")
+    s = s.replace("refund not showing up", "a refund not appearing")
+    return s
+
+
+# Manually-curated cluster map: each label maps to the labels it is most
+# commonly confused with. Used to generate the "Disambiguation" section.
+# Where empty, a generic disambiguation hint is rendered.
+NEAR_NEIGHBOURS: dict[str, list[str]] = {
+    "activate_my_card": ["card_arrival", "card_delivery_estimate"],
+    "card_arrival": ["card_delivery_estimate", "activate_my_card", "order_physical_card"],
+    "card_delivery_estimate": ["card_arrival", "order_physical_card"],
+    "order_physical_card": ["get_physical_card", "card_arrival", "getting_spare_card"],
+    "get_physical_card": ["order_physical_card", "getting_spare_card"],
+    "getting_spare_card": ["order_physical_card", "get_physical_card"],
+    "getting_virtual_card": ["get_disposable_virtual_card", "virtual_card_not_working"],
+    "get_disposable_virtual_card": ["getting_virtual_card", "disposable_card_limits"],
+    "disposable_card_limits": ["get_disposable_virtual_card", "top_up_limits"],
+    "card_about_to_expire": ["card_arrival", "card_not_working"],
+    "card_not_working": ["contactless_not_working", "virtual_card_not_working", "card_swallowed", "declined_card_payment"],
+    "contactless_not_working": ["card_not_working", "declined_card_payment"],
+    "virtual_card_not_working": ["card_not_working", "getting_virtual_card"],
+    "card_swallowed": ["card_not_working", "atm_support"],
+    "card_payment_fee_charged": ["transfer_fee_charged", "extra_charge_on_statement", "exchange_charge"],
+    "card_payment_not_recognised": [
+        "direct_debit_payment_not_recognised",
+        "transaction_charged_twice",
+        "extra_charge_on_statement",
+    ],
+    "card_payment_wrong_exchange_rate": ["exchange_rate", "wrong_exchange_rate_for_cash_withdrawal", "exchange_charge"],
+    "cash_withdrawal_charge": ["card_payment_fee_charged", "exchange_charge", "transfer_fee_charged"],
+    "cash_withdrawal_not_recognised": ["card_payment_not_recognised", "wrong_amount_of_cash_received"],
+    "wrong_amount_of_cash_received": ["cash_withdrawal_not_recognised", "wrong_exchange_rate_for_cash_withdrawal"],
+    "wrong_exchange_rate_for_cash_withdrawal": ["exchange_rate", "card_payment_wrong_exchange_rate"],
+    "declined_card_payment": ["declined_cash_withdrawal", "declined_transfer", "card_not_working"],
+    "declined_cash_withdrawal": ["declined_card_payment", "card_swallowed", "atm_support"],
+    "declined_transfer": ["failed_transfer", "cancel_transfer", "declined_card_payment"],
+    "failed_transfer": ["declined_transfer", "transfer_not_received_by_recipient", "cancel_transfer"],
+    "cancel_transfer": ["declined_transfer", "failed_transfer"],
+    "transfer_not_received_by_recipient": ["transfer_timing", "failed_transfer", "pending_transfer"],
+    "transfer_timing": ["transfer_not_received_by_recipient", "pending_transfer"],
+    "transfer_fee_charged": ["card_payment_fee_charged", "exchange_charge", "extra_charge_on_statement"],
+    "transfer_into_account": ["receiving_money", "balance_not_updated_after_bank_transfer"],
+    "balance_not_updated_after_bank_transfer": [
+        "transfer_into_account",
+        "balance_not_updated_after_cheque_or_cash_deposit",
+        "transfer_timing",
+    ],
+    "balance_not_updated_after_cheque_or_cash_deposit": [
+        "balance_not_updated_after_bank_transfer",
+        "top_up_by_cash_or_cheque",
+    ],
+    "receiving_money": ["transfer_into_account", "balance_not_updated_after_bank_transfer"],
+    "pending_card_payment": ["pending_cash_withdrawal", "pending_transfer", "pending_top_up"],
+    "pending_cash_withdrawal": ["pending_card_payment", "declined_cash_withdrawal"],
+    "pending_top_up": ["top_up_failed", "topping_up_by_card", "pending_card_payment"],
+    "pending_transfer": ["pending_card_payment", "transfer_timing", "failed_transfer"],
+    "top_up_failed": ["pending_top_up", "topping_up_by_card", "top_up_reverted"],
+    "top_up_reverted": ["top_up_failed", "topping_up_by_card"],
+    "top_up_limits": ["disposable_card_limits", "top_up_failed"],
+    "top_up_by_card_charge": ["top_up_by_bank_transfer_charge", "topping_up_by_card", "card_payment_fee_charged"],
+    "top_up_by_bank_transfer_charge": ["top_up_by_card_charge", "transfer_fee_charged"],
+    "top_up_by_cash_or_cheque": ["balance_not_updated_after_cheque_or_cash_deposit"],
+    "topping_up_by_card": ["top_up_by_card_charge", "automatic_top_up", "top_up_failed"],
+    "automatic_top_up": ["topping_up_by_card", "top_up_limits"],
+    "verify_top_up": ["pending_top_up", "verify_my_identity"],
+    "verify_my_identity": ["why_verify_identity", "unable_to_verify_identity", "verify_source_of_funds"],
+    "why_verify_identity": ["verify_my_identity", "verify_source_of_funds"],
+    "unable_to_verify_identity": ["verify_my_identity", "why_verify_identity"],
+    "verify_source_of_funds": ["verify_my_identity", "why_verify_identity"],
+    "request_refund": ["Refund_not_showing_up", "reverted_card_payment?"],
+    "Refund_not_showing_up": ["request_refund", "reverted_card_payment?"],
+    "reverted_card_payment?": ["request_refund", "Refund_not_showing_up", "card_payment_not_recognised"],
+    "transaction_charged_twice": ["card_payment_not_recognised", "extra_charge_on_statement"],
+    "extra_charge_on_statement": ["card_payment_fee_charged", "transfer_fee_charged", "transaction_charged_twice"],
+    "direct_debit_payment_not_recognised": ["card_payment_not_recognised", "transaction_charged_twice"],
+    "lost_or_stolen_card": ["compromised_card", "card_swallowed", "lost_or_stolen_phone"],
+    "compromised_card": ["lost_or_stolen_card", "card_payment_not_recognised"],
+    "lost_or_stolen_phone": ["lost_or_stolen_card"],
+    "passcode_forgotten": ["change_pin", "pin_blocked"],
+    "change_pin": ["pin_blocked", "passcode_forgotten"],
+    "pin_blocked": ["change_pin", "passcode_forgotten", "card_swallowed"],
+    "card_acceptance": ["country_support", "supported_cards_and_currencies", "visa_or_mastercard"],
+    "country_support": ["card_acceptance", "fiat_currency_support"],
+    "supported_cards_and_currencies": ["fiat_currency_support", "visa_or_mastercard", "card_acceptance"],
+    "fiat_currency_support": ["supported_cards_and_currencies", "exchange_rate"],
+    "visa_or_mastercard": ["supported_cards_and_currencies", "card_acceptance"],
+    "exchange_rate": ["card_payment_wrong_exchange_rate", "exchange_charge", "exchange_via_app"],
+    "exchange_charge": ["exchange_rate", "card_payment_fee_charged"],
+    "exchange_via_app": ["exchange_rate", "exchange_charge"],
+    "atm_support": ["card_swallowed", "declined_cash_withdrawal", "card_acceptance"],
+    "edit_personal_details": ["verify_my_identity"],
+    "card_linking": ["apple_pay_or_google_pay"],
+    "apple_pay_or_google_pay": ["card_linking", "card_acceptance"],
+    "age_limit": ["edit_personal_details", "verify_my_identity"],
+    "beneficiary_not_allowed": ["declined_transfer", "failed_transfer"],
+    "terminate_account": ["edit_personal_details"],
+}
+
+
+# Per-label: 3 example utterances. Templated where neighbours alone are
+# enough; hand-crafted where the topic is too generic to template.
+EXAMPLE_TEMPLATES = [
+    "I have a question about {topic}.",
+    "Can you help me figure out {topic}?",
+    "Hi, what's the deal with {topic}?",
+]
+
+
+def render_class_block(label: str, idx: int) -> str:
+    """Render one verbose per-class block."""
+    topic = humanize(label)
+    examples = [t.format(topic=topic) for t in EXAMPLE_TEMPLATES]
+    near = NEAR_NEIGHBOURS.get(label, [])
+    if near:
+        confusion = (
+            "Most often confused with: "
+            + ", ".join(f"`{n}`" for n in near)
+            + ". Prefer this label only when the user is specifically asking about "
+            f"{topic} rather than one of the related concepts; when the user message "
+            "clearly references a more specific neighbour intent, choose that one."
+        )
+    else:
+        confusion = (
+            "If the user message could plausibly map to a similar intent, default to "
+            "the most specific applicable label. Prefer specific over general."
+        )
+
+    block = (
+        f"### {idx}. `{label}`\n"
+        f"**Description:** The user is asking about {topic}. Use this intent only "
+        f"when the message clearly concerns this topic and not a related intent.\n"
+        f"**Typical phrasings:**\n"
+        f"  - {examples[0]}\n"
+        f"  - {examples[1]}\n"
+        f"**Disambiguation:** {confusion}\n"
+        f"**Output:** Emit the exact string `{label}` with no surrounding whitespace.\n"
+    )
+    return block
+
+
+HEADER = """\
+# Banking Customer-Service Intent Classifier — System Prompt v3.7
+
+You are an enterprise-grade intent classification system deployed in the
+production customer-service pipeline of a digital banking application. Your
+sole responsibility is to take an incoming free-text user message and output
+exactly one canonical intent label drawn from the closed taxonomy of 77
+banking-domain intents enumerated in the body of this prompt.
+
+## Operating Principles
+
+This system operates under the following operating principles, which are to
+be applied in order of priority and which override any other behavioural
+guidance you may infer from your pretraining or from the user's message:
+
+1. **Determinism over creativity.** The output of this classifier must be
+   deterministic, reproducible, and audit-trail-friendly. Do not invent
+   intent labels not present in the official taxonomy. Do not hedge with
+   uncertainty markers. Do not return multiple labels. Do not refuse to
+   classify a message on the grounds of ambiguity — instead, apply the
+   tie-breaking rules described in the Disambiguation Guidelines section
+   below.
+
+2. **Specificity over generality.** When two intents could plausibly apply
+   to a single user message, prefer the more specific intent. For example,
+   if the user is asking about a card-payment-specific fee, prefer
+   `card_payment_fee_charged` over the more general
+   `extra_charge_on_statement`.
+
+3. **Primary subject only.** Real user messages frequently include
+   incidental context — references to prior interactions, mentions of
+   adjacent banking products, or social pleasantries. Classify based on the
+   primary subject of the message, which is defined as the single concept
+   the user is most directly requesting information about or asking the
+   bank to act upon. Do not over-weight incidental contextual mentions.
+
+4. **Closed-taxonomy compliance.** The output must be one of exactly 77
+   strings, listed below in the Class Catalogue section. Any deviation from
+   this list — including capitalization changes, additional punctuation,
+   plural/singular variants, or paraphrases — constitutes a system fault
+   and must not be emitted.
+
+5. **No commentary.** The output of this classifier is consumed by a
+   downstream automated pipeline. Do not emit explanations, justifications,
+   confidence scores, or step-by-step reasoning. Output only the single
+   canonical label string.
+
+## Output Format Specification
+
+Your output must consist of exactly one of the 77 canonical label strings
+listed in the Class Catalogue. The output:
+
+  - MUST be a single line.
+  - MUST contain no leading or trailing whitespace beyond the canonical
+    string itself.
+  - MUST contain no quotation marks, backticks, or other delimiters.
+  - MUST contain no commentary, no chain-of-thought, no preamble, no
+    "The intent is" framing, no JSON, no markdown formatting.
+  - MUST exactly match (character-for-character, including underscores
+    and any trailing question mark or capitalization quirks) one of the
+    77 strings listed in the Class Catalogue below. Note in particular that
+    `Refund_not_showing_up` has a capital R and `reverted_card_payment?`
+    ends with a question mark; these are intentional canonical forms and
+    must be preserved exactly.
+
+## Disambiguation Guidelines (General)
+
+When two or more intents seem to apply, walk through the following
+hierarchy of tie-breakers in order:
+
+  1. **Specificity tier.** Prefer the more specific intent over the more
+     general intent. Card-specific intents beat generic intents when the
+     message is about cards. Top-up-specific intents beat generic
+     transaction intents when the message is about top-ups.
+
+  2. **Action vs. status tier.** If the user is asking the bank to do
+     something (e.g., activate, cancel, change), prefer the action intent.
+     If the user is asking about the state of something (e.g., pending,
+     declined, not received), prefer the status intent.
+
+  3. **Failure-mode specificity.** If the user is reporting that something
+     went wrong, prefer the failure-mode intent that most precisely
+     matches the failure described (e.g., `declined_card_payment` over
+     `card_not_working` when a specific transaction declined).
+
+  4. **Verification cluster.** Verification-related intents
+     (`verify_my_identity`, `why_verify_identity`,
+     `unable_to_verify_identity`, `verify_source_of_funds`,
+     `verify_top_up`) are commonly confused. Read the user message
+     carefully: if the user is asking how to perform verification, use
+     `verify_my_identity`; if they are asking why verification is required,
+     use `why_verify_identity`; if they are reporting that the
+     verification process has failed, use `unable_to_verify_identity`.
+
+  5. **Refund cluster.** Refund-related intents (`request_refund`,
+     `Refund_not_showing_up`, `reverted_card_payment?`) follow a similar
+     pattern: use `request_refund` when the user is initiating a refund
+     request; use `Refund_not_showing_up` when the user expects a refund
+     but has not yet seen it; use `reverted_card_payment?` when the user
+     is asking whether a recent card payment has been reversed.
+
+  6. **Pending cluster.** Pending-related intents are differentiated by
+     the underlying transaction type: card payment, cash withdrawal,
+     top-up, or transfer. Identify which transaction type the user is
+     describing and select the corresponding pending intent.
+
+If after walking through the above tiers two intents remain equally
+plausible, prefer the lexicographically earlier intent label. This rule is
+included as a final, deterministic tie-breaker; in practice it is rarely
+invoked because the prior tiers usually resolve ambiguity.
+
+## Class Catalogue
+
+The 77 canonical intents are enumerated below in the canonical index order.
+Each intent is documented with a description, typical phrasings the user
+may employ to express the intent, disambiguation guidance for nearby
+intents in the taxonomy, and edge-case handling rules. You should consult
+this catalogue when classifying every incoming user message.
+
+"""
+
+
+FOOTER = """\
+
+## Frequently-Asked Questions (For Classifier Behaviour)
+
+**Q: What if the user message is in a non-English language?**
+A: This classifier is monolingual English. If the message is clearly not in
+English, attempt to translate the user's intent and apply the standard
+classification rules. Do not refuse the classification.
+
+**Q: What if the user message is gibberish or empty?**
+A: Apply the standard classification rules to the best of your ability.
+The classifier is not responsible for upstream input quality. Output the
+single most plausible intent label given the available signal.
+
+**Q: What if the user is angry or using profanity?**
+A: Tone is not signal for intent. Strip the affective content from the
+message and classify on the underlying request.
+
+**Q: What if the user is asking about something not in the 77 intents?**
+A: This is a closed taxonomy. Output the single most plausible intent
+label from the 77 even if no intent perfectly fits. Do not output a
+fallback "other" or "unknown" — those are not in the taxonomy.
+
+**Q: What if the user message contains multiple intents?**
+A: Apply the Primary Subject Only rule from the Operating Principles
+section. Identify the single primary intent and output only that label.
+
+## Common Classifier Mistakes (Anti-patterns to Avoid)
+
+The following are anti-patterns frequently observed in classifier outputs
+and are to be strictly avoided:
+
+  - **Outputting a paraphrase of a label.** Output `card_arrival`, not
+    `card has arrived` or `arrival of card`. The canonical label string
+    is the only acceptable output.
+
+  - **Outputting a label not in the taxonomy.** Even if a label seems
+    intuitively appropriate, only the 77 canonical labels are valid.
+    `card_status_check`, for example, is not a valid label.
+
+  - **Outputting multiple labels.** Output exactly one label.
+
+  - **Outputting JSON or structured output.** The contract is a single
+    plain-text label string per line.
+
+  - **Outputting commentary.** Do not output "I think the intent is..." or
+    "The user is asking about..." — output the bare label.
+
+  - **Outputting capitalization variants.** Match the canonical
+    capitalization exactly. `Refund_not_showing_up` is the only correct
+    capitalization for that intent.
+
+  - **Outputting label IDs or numbers.** Do not output an integer index
+    such as `42` — output the canonical string label.
+
+## Worked Examples
+
+Worked example 1.
+User message: "Hi there, my card hasn't arrived yet, it's been over a week now"
+Correct output: card_arrival
+
+Worked example 2.
+User message: "How do I get my new card to work? It just showed up in the mail"
+Correct output: activate_my_card
+
+Worked example 3.
+User message: "Why was I charged a fee on this card payment?"
+Correct output: card_payment_fee_charged
+
+Worked example 4.
+User message: "I lost my phone and I'm worried about my card"
+Correct output: lost_or_stolen_phone
+
+Worked example 5.
+User message: "The ATM didn't give me the right amount of cash"
+Correct output: wrong_amount_of_cash_received
+
+Worked example 6.
+User message: "I need to verify who I am, how do I do that?"
+Correct output: verify_my_identity
+
+Worked example 7.
+User message: "Can I add this card to Apple Pay?"
+Correct output: apple_pay_or_google_pay
+
+Worked example 8.
+User message: "I'd like to close my account"
+Correct output: terminate_account
+
+Worked example 9.
+User message: "My contactless isn't working anymore"
+Correct output: contactless_not_working
+
+Worked example 10.
+User message: "Can I send money internationally?"
+Correct output: country_support
+
+## Final Reminder
+
+Output exactly one of the 77 canonical labels. No commentary. No
+formatting. No additional whitespace. The downstream pipeline depends on
+strict format compliance.
+
+End of system prompt v3.7.
+"""
+
+
+def build_prompt() -> str:
+    parts = [HEADER]
+    for idx, label in enumerate(LABELS, start=1):
+        parts.append(render_class_block(label, idx))
+        parts.append("\n")
+    parts.append(FOOTER)
+    return "".join(parts)
+
+
+if __name__ == "__main__":
+    p = build_prompt()
+    sys.stdout.write(p)
+    sys.stderr.write(f"\n[built prompt: {len(p):,} chars, {len(LABELS)} classes]\n")

--- a/examples/prompt-compression/eval.py
+++ b/examples/prompt-compression/eval.py
@@ -1,0 +1,122 @@
+"""Evaluation script Weco invokes after each prompt mutation.
+
+Loads a held-out slice of PolyAI/banking77, runs ``optimize.classify`` on each
+example in parallel, parses predicted labels, and emits three lines on stdout
+that Weco can read:
+
+    accuracy: <0..1>
+    chars:    <int>
+    metric:   <int>     # the value Weco minimizes
+
+The composite ``metric`` is **quality-constrained minimize chars**:
+    metric = chars                if accuracy >= ACCURACY_THRESHOLD
+    metric = chars + huge penalty otherwise
+
+This gives a clean narrative ("we kept accuracy at or above the baseline and
+got X% smaller") and makes Weco's optimization target unambiguous.
+"""
+
+from __future__ import annotations
+import concurrent.futures
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from labels import LABELS, parse_predicted_label  # noqa: E402
+import optimize  # noqa: E402  -- the file Weco mutates
+
+# --- configuration ---------------------------------------------------------
+
+EVAL_MODEL = os.environ.get("EVAL_MODEL", "gpt-5-mini")
+N_SAMPLES = int(os.environ.get("EVAL_SAMPLES", "200"))
+N_WORKERS = int(os.environ.get("EVAL_WORKERS", "20"))
+SEED = int(os.environ.get("EVAL_SEED", "0"))
+
+# Accuracy threshold the compressed prompt must hold above. Loaded from
+# baseline_accuracy.json if present (written by measure_baseline.py); falls
+# back to a conservative default.
+_BASELINE_FILE = ROOT / "baseline_accuracy.json"
+if _BASELINE_FILE.exists():
+    _baseline = json.loads(_BASELINE_FILE.read_text())
+    BASELINE_ACC = float(_baseline["accuracy"])
+    SLACK = float(os.environ.get("EVAL_SLACK", "0.02"))
+    ACCURACY_THRESHOLD = max(0.0, BASELINE_ACC - SLACK)
+else:
+    BASELINE_ACC = None
+    ACCURACY_THRESHOLD = float(os.environ.get("EVAL_THRESHOLD", "0.75"))
+
+PENALTY = 10_000_000  # added to chars when accuracy is below threshold
+
+# --- main ------------------------------------------------------------------
+
+
+def _load_eval_set():
+    """Return a list of (text, gold_label) tuples sampled from the test split."""
+    from datasets import load_dataset  # heavy import — lazy
+
+    ds = load_dataset("PolyAI/banking77", split="test", trust_remote_code=True)
+    ds = ds.shuffle(seed=SEED).select(range(min(N_SAMPLES, len(ds))))
+    return [(ex["text"], LABELS[ex["label"]]) for ex in ds]
+
+
+def _classify_one(item):
+    text, gold = item
+    raw = optimize.classify(text, model=EVAL_MODEL)
+    pred = parse_predicted_label(raw)
+    return text, gold, pred, raw
+
+
+def main() -> int:
+    t0 = time.time()
+    print(f"[setup] loading {N_SAMPLES} BANKING77 test samples (seed={SEED})", file=sys.stderr)
+    eval_set = _load_eval_set()
+    n = len(eval_set)
+    print(f"[setup] running {n} classifications via {EVAL_MODEL} ({N_WORKERS} workers)", file=sys.stderr)
+
+    correct = 0
+    parsed = 0
+    log_every = max(1, n // 5)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=N_WORKERS) as ex:
+        for i, (text, gold, pred, _raw) in enumerate(ex.map(_classify_one, eval_set), start=1):
+            if pred is not None:
+                parsed += 1
+                if pred == gold:
+                    correct += 1
+            if i % log_every == 0 or i == n:
+                running = correct / i
+                elapsed = time.time() - t0
+                print(
+                    f"[progress] {i}/{n} completed, accuracy: {running:.4f}, "
+                    f"parse-rate: {parsed / i:.4f}, elapsed {elapsed:.1f}s",
+                    file=sys.stderr,
+                )
+
+    accuracy = correct / n
+    chars = len(optimize.SYSTEM_PROMPT)
+    if accuracy >= ACCURACY_THRESHOLD:
+        metric = chars
+    else:
+        metric = chars + PENALTY
+
+    print(f"accuracy: {accuracy:.4f}")
+    print(f"chars: {chars}")
+    print(f"metric: {metric}")
+
+    msg = (
+        f"[summary] accuracy={accuracy:.4f}  threshold={ACCURACY_THRESHOLD:.4f}  "
+        f"chars={chars:,}  metric={metric:,}  "
+        f"parse_rate={parsed / n:.4f}  elapsed={time.time() - t0:.1f}s"
+    )
+    print(msg, file=sys.stderr)
+    if BASELINE_ACC is not None:
+        print(f"[summary] baseline_accuracy={BASELINE_ACC:.4f} (from baseline_accuracy.json)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/prompt-compression/labels.py
+++ b/examples/prompt-compression/labels.py
@@ -1,0 +1,146 @@
+"""BANKING77 intent labels.
+
+The PolyAI/banking77 dataset (https://huggingface.co/datasets/PolyAI/banking77)
+defines 77 fine-grained banking customer-service intents. The labels are
+exposed by the HF dataset's ClassLabel feature in this exact index order;
+do NOT reorder.
+"""
+
+LABELS = [
+    "activate_my_card",
+    "age_limit",
+    "apple_pay_or_google_pay",
+    "atm_support",
+    "automatic_top_up",
+    "balance_not_updated_after_bank_transfer",
+    "balance_not_updated_after_cheque_or_cash_deposit",
+    "beneficiary_not_allowed",
+    "cancel_transfer",
+    "card_about_to_expire",
+    "card_acceptance",
+    "card_arrival",
+    "card_delivery_estimate",
+    "card_linking",
+    "card_not_working",
+    "card_payment_fee_charged",
+    "card_payment_not_recognised",
+    "card_payment_wrong_exchange_rate",
+    "card_swallowed",
+    "cash_withdrawal_charge",
+    "cash_withdrawal_not_recognised",
+    "change_pin",
+    "compromised_card",
+    "contactless_not_working",
+    "country_support",
+    "declined_card_payment",
+    "declined_cash_withdrawal",
+    "declined_transfer",
+    "direct_debit_payment_not_recognised",
+    "disposable_card_limits",
+    "edit_personal_details",
+    "exchange_charge",
+    "exchange_rate",
+    "exchange_via_app",
+    "extra_charge_on_statement",
+    "failed_transfer",
+    "fiat_currency_support",
+    "get_disposable_virtual_card",
+    "get_physical_card",
+    "getting_spare_card",
+    "getting_virtual_card",
+    "lost_or_stolen_card",
+    "lost_or_stolen_phone",
+    "order_physical_card",
+    "passcode_forgotten",
+    "pending_card_payment",
+    "pending_cash_withdrawal",
+    "pending_top_up",
+    "pending_transfer",
+    "pin_blocked",
+    "receiving_money",
+    "Refund_not_showing_up",
+    "request_refund",
+    "reverted_card_payment?",
+    "supported_cards_and_currencies",
+    "terminate_account",
+    "top_up_by_bank_transfer_charge",
+    "top_up_by_card_charge",
+    "top_up_by_cash_or_cheque",
+    "top_up_failed",
+    "top_up_limits",
+    "top_up_reverted",
+    "topping_up_by_card",
+    "transaction_charged_twice",
+    "transfer_fee_charged",
+    "transfer_into_account",
+    "transfer_not_received_by_recipient",
+    "transfer_timing",
+    "unable_to_verify_identity",
+    "verify_my_identity",
+    "verify_source_of_funds",
+    "verify_top_up",
+    "virtual_card_not_working",
+    "visa_or_mastercard",
+    "why_verify_identity",
+    "wrong_amount_of_cash_received",
+    "wrong_exchange_rate_for_cash_withdrawal",
+]
+
+assert len(LABELS) == 77, f"Expected 77 labels, got {len(LABELS)}"
+assert len(set(LABELS)) == 77, "Duplicate labels detected"
+
+
+def normalize(s: str) -> str:
+    """Canonicalize a string for label matching."""
+    return s.strip().lower().replace(" ", "_").replace("-", "_").rstrip("?").rstrip(".")
+
+
+_NORMALIZED_LABELS = {normalize(L): L for L in LABELS}
+
+
+def parse_predicted_label(model_output: str) -> str | None:
+    """Extract a canonical label from the model's free-text response.
+
+    Strategy:
+      1. Strict match: the entire response normalizes to a known label.
+      2. First-line match: the first line normalizes to a known label.
+      3. Substring scan: scan for any normalized label appearing in the text;
+         return the longest match (most specific).
+    Returns None if no label can be recovered.
+    """
+    text = (model_output or "").strip()
+    if not text:
+        return None
+
+    norm_full = normalize(text)
+    if norm_full in _NORMALIZED_LABELS:
+        return _NORMALIZED_LABELS[norm_full]
+
+    first_line = normalize(text.splitlines()[0])
+    if first_line in _NORMALIZED_LABELS:
+        return _NORMALIZED_LABELS[first_line]
+
+    candidates = []
+    norm_text = "_" + normalize(text) + "_"
+    for norm, canonical in _NORMALIZED_LABELS.items():
+        if "_" + norm + "_" in norm_text or norm in norm_text:
+            candidates.append(canonical)
+    if candidates:
+        return max(candidates, key=len)
+
+    return None
+
+
+def verify_against_huggingface() -> None:
+    """Sanity-check our LABELS against the live HF dataset's ClassLabel."""
+    from datasets import load_dataset  # noqa: WPS433
+
+    ds = load_dataset("PolyAI/banking77", split="test", trust_remote_code=True)
+    hf_labels = ds.features["label"].names
+    if hf_labels != LABELS:
+        raise AssertionError(f"Label mismatch with PolyAI/banking77.\n  HF: {hf_labels}\n  ours: {LABELS}")
+    print("OK: 77 labels match PolyAI/banking77 ClassLabel order.")
+
+
+if __name__ == "__main__":
+    verify_against_huggingface()

--- a/examples/prompt-compression/measure_baseline.py
+++ b/examples/prompt-compression/measure_baseline.py
@@ -1,0 +1,79 @@
+"""Measure the baseline accuracy of the bloated SYSTEM_PROMPT and freeze it.
+
+Run once before kicking off Weco:
+
+    python measure_baseline.py
+
+Output: ``baseline_accuracy.json`` next to this script. ``eval.py`` reads
+that file to set the accuracy floor that compressed prompts must respect.
+"""
+
+from __future__ import annotations
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from labels import LABELS, parse_predicted_label  # noqa: E402
+import optimize  # noqa: E402
+
+EVAL_MODEL = os.environ.get("EVAL_MODEL", "gpt-5-mini")
+N_SAMPLES = int(os.environ.get("EVAL_SAMPLES", "200"))
+N_WORKERS = int(os.environ.get("EVAL_WORKERS", "20"))
+SEED = int(os.environ.get("EVAL_SEED", "0"))
+
+
+def main() -> int:
+    import concurrent.futures
+    from datasets import load_dataset
+
+    t0 = time.time()
+    print(f"[baseline] model={EVAL_MODEL} samples={N_SAMPLES} seed={SEED}")
+    print(f"[baseline] SYSTEM_PROMPT chars={len(optimize.SYSTEM_PROMPT):,}")
+
+    ds = load_dataset("PolyAI/banking77", split="test", trust_remote_code=True).shuffle(seed=SEED)
+    ds = ds.select(range(min(N_SAMPLES, len(ds))))
+    items = [(ex["text"], LABELS[ex["label"]]) for ex in ds]
+
+    def run_one(item):
+        text, gold = item
+        raw = optimize.classify(text, model=EVAL_MODEL)
+        return parse_predicted_label(raw), gold
+
+    correct = 0
+    parsed = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=N_WORKERS) as ex:
+        for i, (pred, gold) in enumerate(ex.map(run_one, items), start=1):
+            if pred is not None:
+                parsed += 1
+                if pred == gold:
+                    correct += 1
+            if i % max(1, len(items) // 10) == 0:
+                print(
+                    f"[baseline] {i}/{len(items)}  acc={correct / i:.4f}  "
+                    f"parse={parsed / i:.4f}  elapsed={time.time() - t0:.1f}s"
+                )
+
+    accuracy = correct / len(items)
+    out = {
+        "accuracy": accuracy,
+        "n_samples": len(items),
+        "model": EVAL_MODEL,
+        "seed": SEED,
+        "chars": len(optimize.SYSTEM_PROMPT),
+        "parse_rate": parsed / len(items),
+        "elapsed_seconds": time.time() - t0,
+    }
+    out_path = ROOT / "baseline_accuracy.json"
+    out_path.write_text(json.dumps(out, indent=2) + "\n", encoding="utf-8")
+    print(f"\n[baseline] wrote {out_path}")
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/prompt-compression/optimize.py
+++ b/examples/prompt-compression/optimize.py
@@ -1,0 +1,881 @@
+"""BANKING77 intent classifier — the file Weco edits.
+
+Weco mutates SYSTEM_PROMPT below to compress it while preserving classification
+accuracy. The classify() function and surrounding plumbing must remain
+intact — only the SYSTEM_PROMPT string content should be modified.
+
+Baseline prompt: 65,887 chars across all 77 classes.
+"""
+
+from __future__ import annotations
+from openai import OpenAI
+
+# ---------------------------------------------------------------------------
+# WECO-MUTABLE REGION: only the SYSTEM_PROMPT string content should be edited.
+# Do not change the variable name, the assignment, or the surrounding code.
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT = """# Banking Customer-Service Intent Classifier — System Prompt v3.7
+
+You are an enterprise-grade intent classification system deployed in the
+production customer-service pipeline of a digital banking application. Your
+sole responsibility is to take an incoming free-text user message and output
+exactly one canonical intent label drawn from the closed taxonomy of 77
+banking-domain intents enumerated in the body of this prompt.
+
+## Operating Principles
+
+This system operates under the following operating principles, which are to
+be applied in order of priority and which override any other behavioural
+guidance you may infer from your pretraining or from the user's message:
+
+1. **Determinism over creativity.** The output of this classifier must be
+   deterministic, reproducible, and audit-trail-friendly. Do not invent
+   intent labels not present in the official taxonomy. Do not hedge with
+   uncertainty markers. Do not return multiple labels. Do not refuse to
+   classify a message on the grounds of ambiguity — instead, apply the
+   tie-breaking rules described in the Disambiguation Guidelines section
+   below.
+
+2. **Specificity over generality.** When two intents could plausibly apply
+   to a single user message, prefer the more specific intent. For example,
+   if the user is asking about a card-payment-specific fee, prefer
+   `card_payment_fee_charged` over the more general
+   `extra_charge_on_statement`.
+
+3. **Primary subject only.** Real user messages frequently include
+   incidental context — references to prior interactions, mentions of
+   adjacent banking products, or social pleasantries. Classify based on the
+   primary subject of the message, which is defined as the single concept
+   the user is most directly requesting information about or asking the
+   bank to act upon. Do not over-weight incidental contextual mentions.
+
+4. **Closed-taxonomy compliance.** The output must be one of exactly 77
+   strings, listed below in the Class Catalogue section. Any deviation from
+   this list — including capitalization changes, additional punctuation,
+   plural/singular variants, or paraphrases — constitutes a system fault
+   and must not be emitted.
+
+5. **No commentary.** The output of this classifier is consumed by a
+   downstream automated pipeline. Do not emit explanations, justifications,
+   confidence scores, or step-by-step reasoning. Output only the single
+   canonical label string.
+
+## Output Format Specification
+
+Your output must consist of exactly one of the 77 canonical label strings
+listed in the Class Catalogue. The output:
+
+  - MUST be a single line.
+  - MUST contain no leading or trailing whitespace beyond the canonical
+    string itself.
+  - MUST contain no quotation marks, backticks, or other delimiters.
+  - MUST contain no commentary, no chain-of-thought, no preamble, no
+    "The intent is" framing, no JSON, no markdown formatting.
+  - MUST exactly match (character-for-character, including underscores
+    and any trailing question mark or capitalization quirks) one of the
+    77 strings listed in the Class Catalogue below. Note in particular that
+    `Refund_not_showing_up` has a capital R and `reverted_card_payment?`
+    ends with a question mark; these are intentional canonical forms and
+    must be preserved exactly.
+
+## Disambiguation Guidelines (General)
+
+When two or more intents seem to apply, walk through the following
+hierarchy of tie-breakers in order:
+
+  1. **Specificity tier.** Prefer the more specific intent over the more
+     general intent. Card-specific intents beat generic intents when the
+     message is about cards. Top-up-specific intents beat generic
+     transaction intents when the message is about top-ups.
+
+  2. **Action vs. status tier.** If the user is asking the bank to do
+     something (e.g., activate, cancel, change), prefer the action intent.
+     If the user is asking about the state of something (e.g., pending,
+     declined, not received), prefer the status intent.
+
+  3. **Failure-mode specificity.** If the user is reporting that something
+     went wrong, prefer the failure-mode intent that most precisely
+     matches the failure described (e.g., `declined_card_payment` over
+     `card_not_working` when a specific transaction declined).
+
+  4. **Verification cluster.** Verification-related intents
+     (`verify_my_identity`, `why_verify_identity`,
+     `unable_to_verify_identity`, `verify_source_of_funds`,
+     `verify_top_up`) are commonly confused. Read the user message
+     carefully: if the user is asking how to perform verification, use
+     `verify_my_identity`; if they are asking why verification is required,
+     use `why_verify_identity`; if they are reporting that the
+     verification process has failed, use `unable_to_verify_identity`.
+
+  5. **Refund cluster.** Refund-related intents (`request_refund`,
+     `Refund_not_showing_up`, `reverted_card_payment?`) follow a similar
+     pattern: use `request_refund` when the user is initiating a refund
+     request; use `Refund_not_showing_up` when the user expects a refund
+     but has not yet seen it; use `reverted_card_payment?` when the user
+     is asking whether a recent card payment has been reversed.
+
+  6. **Pending cluster.** Pending-related intents are differentiated by
+     the underlying transaction type: card payment, cash withdrawal,
+     top-up, or transfer. Identify which transaction type the user is
+     describing and select the corresponding pending intent.
+
+If after walking through the above tiers two intents remain equally
+plausible, prefer the lexicographically earlier intent label. This rule is
+included as a final, deterministic tie-breaker; in practice it is rarely
+invoked because the prior tiers usually resolve ambiguity.
+
+## Class Catalogue
+
+The 77 canonical intents are enumerated below in the canonical index order.
+Each intent is documented with a description, typical phrasings the user
+may employ to express the intent, disambiguation guidance for nearby
+intents in the taxonomy, and edge-case handling rules. You should consult
+this catalogue when classifying every incoming user message.
+
+### 1. `activate_my_card`
+**Description:** The user is asking about activate my card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about activate my card.
+  - Can you help me figure out activate my card?
+**Disambiguation:** Most often confused with: `card_arrival`, `card_delivery_estimate`. Prefer this label only when the user is specifically asking about activate my card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `activate_my_card` with no surrounding whitespace.
+
+### 2. `age_limit`
+**Description:** The user is asking about age limit. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about age limit.
+  - Can you help me figure out age limit?
+**Disambiguation:** Most often confused with: `edit_personal_details`, `verify_my_identity`. Prefer this label only when the user is specifically asking about age limit rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `age_limit` with no surrounding whitespace.
+
+### 3. `apple_pay_or_google_pay`
+**Description:** The user is asking about Apple Pay or Google Pay. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about Apple Pay or Google Pay.
+  - Can you help me figure out Apple Pay or Google Pay?
+**Disambiguation:** Most often confused with: `card_linking`, `card_acceptance`. Prefer this label only when the user is specifically asking about Apple Pay or Google Pay rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `apple_pay_or_google_pay` with no surrounding whitespace.
+
+### 4. `atm_support`
+**Description:** The user is asking about ATM support. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about ATM support.
+  - Can you help me figure out ATM support?
+**Disambiguation:** Most often confused with: `card_swallowed`, `declined_cash_withdrawal`, `card_acceptance`. Prefer this label only when the user is specifically asking about ATM support rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `atm_support` with no surrounding whitespace.
+
+### 5. `automatic_top_up`
+**Description:** The user is asking about automatic top up. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about automatic top up.
+  - Can you help me figure out automatic top up?
+**Disambiguation:** Most often confused with: `topping_up_by_card`, `top_up_limits`. Prefer this label only when the user is specifically asking about automatic top up rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `automatic_top_up` with no surrounding whitespace.
+
+### 6. `balance_not_updated_after_bank_transfer`
+**Description:** The user is asking about balance not updated after bank transfer. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about balance not updated after bank transfer.
+  - Can you help me figure out balance not updated after bank transfer?
+**Disambiguation:** Most often confused with: `transfer_into_account`, `balance_not_updated_after_cheque_or_cash_deposit`, `transfer_timing`. Prefer this label only when the user is specifically asking about balance not updated after bank transfer rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `balance_not_updated_after_bank_transfer` with no surrounding whitespace.
+
+### 7. `balance_not_updated_after_cheque_or_cash_deposit`
+**Description:** The user is asking about balance not updated after cheque or cash deposit. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about balance not updated after cheque or cash deposit.
+  - Can you help me figure out balance not updated after cheque or cash deposit?
+**Disambiguation:** Most often confused with: `balance_not_updated_after_bank_transfer`, `top_up_by_cash_or_cheque`. Prefer this label only when the user is specifically asking about balance not updated after cheque or cash deposit rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `balance_not_updated_after_cheque_or_cash_deposit` with no surrounding whitespace.
+
+### 8. `beneficiary_not_allowed`
+**Description:** The user is asking about beneficiary not allowed. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about beneficiary not allowed.
+  - Can you help me figure out beneficiary not allowed?
+**Disambiguation:** Most often confused with: `declined_transfer`, `failed_transfer`. Prefer this label only when the user is specifically asking about beneficiary not allowed rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `beneficiary_not_allowed` with no surrounding whitespace.
+
+### 9. `cancel_transfer`
+**Description:** The user is asking about cancel transfer. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about cancel transfer.
+  - Can you help me figure out cancel transfer?
+**Disambiguation:** Most often confused with: `declined_transfer`, `failed_transfer`. Prefer this label only when the user is specifically asking about cancel transfer rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `cancel_transfer` with no surrounding whitespace.
+
+### 10. `card_about_to_expire`
+**Description:** The user is asking about card about to expire. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card about to expire.
+  - Can you help me figure out card about to expire?
+**Disambiguation:** Most often confused with: `card_arrival`, `card_not_working`. Prefer this label only when the user is specifically asking about card about to expire rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_about_to_expire` with no surrounding whitespace.
+
+### 11. `card_acceptance`
+**Description:** The user is asking about card acceptance. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card acceptance.
+  - Can you help me figure out card acceptance?
+**Disambiguation:** Most often confused with: `country_support`, `supported_cards_and_currencies`, `visa_or_mastercard`. Prefer this label only when the user is specifically asking about card acceptance rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_acceptance` with no surrounding whitespace.
+
+### 12. `card_arrival`
+**Description:** The user is asking about card arrival. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card arrival.
+  - Can you help me figure out card arrival?
+**Disambiguation:** Most often confused with: `card_delivery_estimate`, `activate_my_card`, `order_physical_card`. Prefer this label only when the user is specifically asking about card arrival rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_arrival` with no surrounding whitespace.
+
+### 13. `card_delivery_estimate`
+**Description:** The user is asking about card delivery estimate. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card delivery estimate.
+  - Can you help me figure out card delivery estimate?
+**Disambiguation:** Most often confused with: `card_arrival`, `order_physical_card`. Prefer this label only when the user is specifically asking about card delivery estimate rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_delivery_estimate` with no surrounding whitespace.
+
+### 14. `card_linking`
+**Description:** The user is asking about card linking. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card linking.
+  - Can you help me figure out card linking?
+**Disambiguation:** Most often confused with: `apple_pay_or_google_pay`. Prefer this label only when the user is specifically asking about card linking rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_linking` with no surrounding whitespace.
+
+### 15. `card_not_working`
+**Description:** The user is asking about card not working. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card not working.
+  - Can you help me figure out card not working?
+**Disambiguation:** Most often confused with: `contactless_not_working`, `virtual_card_not_working`, `card_swallowed`, `declined_card_payment`. Prefer this label only when the user is specifically asking about card not working rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_not_working` with no surrounding whitespace.
+
+### 16. `card_payment_fee_charged`
+**Description:** The user is asking about card payment fee charged. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card payment fee charged.
+  - Can you help me figure out card payment fee charged?
+**Disambiguation:** Most often confused with: `transfer_fee_charged`, `extra_charge_on_statement`, `exchange_charge`. Prefer this label only when the user is specifically asking about card payment fee charged rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_payment_fee_charged` with no surrounding whitespace.
+
+### 17. `card_payment_not_recognised`
+**Description:** The user is asking about card payment not recognised. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card payment not recognised.
+  - Can you help me figure out card payment not recognised?
+**Disambiguation:** Most often confused with: `direct_debit_payment_not_recognised`, `transaction_charged_twice`, `extra_charge_on_statement`. Prefer this label only when the user is specifically asking about card payment not recognised rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_payment_not_recognised` with no surrounding whitespace.
+
+### 18. `card_payment_wrong_exchange_rate`
+**Description:** The user is asking about card payment wrong exchange rate. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card payment wrong exchange rate.
+  - Can you help me figure out card payment wrong exchange rate?
+**Disambiguation:** Most often confused with: `exchange_rate`, `wrong_exchange_rate_for_cash_withdrawal`, `exchange_charge`. Prefer this label only when the user is specifically asking about card payment wrong exchange rate rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_payment_wrong_exchange_rate` with no surrounding whitespace.
+
+### 19. `card_swallowed`
+**Description:** The user is asking about card swallowed. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about card swallowed.
+  - Can you help me figure out card swallowed?
+**Disambiguation:** Most often confused with: `card_not_working`, `atm_support`. Prefer this label only when the user is specifically asking about card swallowed rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `card_swallowed` with no surrounding whitespace.
+
+### 20. `cash_withdrawal_charge`
+**Description:** The user is asking about cash withdrawal charge. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about cash withdrawal charge.
+  - Can you help me figure out cash withdrawal charge?
+**Disambiguation:** Most often confused with: `card_payment_fee_charged`, `exchange_charge`, `transfer_fee_charged`. Prefer this label only when the user is specifically asking about cash withdrawal charge rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `cash_withdrawal_charge` with no surrounding whitespace.
+
+### 21. `cash_withdrawal_not_recognised`
+**Description:** The user is asking about cash withdrawal not recognised. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about cash withdrawal not recognised.
+  - Can you help me figure out cash withdrawal not recognised?
+**Disambiguation:** Most often confused with: `card_payment_not_recognised`, `wrong_amount_of_cash_received`. Prefer this label only when the user is specifically asking about cash withdrawal not recognised rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `cash_withdrawal_not_recognised` with no surrounding whitespace.
+
+### 22. `change_pin`
+**Description:** The user is asking about change PIN. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about change PIN.
+  - Can you help me figure out change PIN?
+**Disambiguation:** Most often confused with: `pin_blocked`, `passcode_forgotten`. Prefer this label only when the user is specifically asking about change PIN rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `change_pin` with no surrounding whitespace.
+
+### 23. `compromised_card`
+**Description:** The user is asking about compromised card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about compromised card.
+  - Can you help me figure out compromised card?
+**Disambiguation:** Most often confused with: `lost_or_stolen_card`, `card_payment_not_recognised`. Prefer this label only when the user is specifically asking about compromised card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `compromised_card` with no surrounding whitespace.
+
+### 24. `contactless_not_working`
+**Description:** The user is asking about contactless not working. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about contactless not working.
+  - Can you help me figure out contactless not working?
+**Disambiguation:** Most often confused with: `card_not_working`, `declined_card_payment`. Prefer this label only when the user is specifically asking about contactless not working rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `contactless_not_working` with no surrounding whitespace.
+
+### 25. `country_support`
+**Description:** The user is asking about country support. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about country support.
+  - Can you help me figure out country support?
+**Disambiguation:** Most often confused with: `card_acceptance`, `fiat_currency_support`. Prefer this label only when the user is specifically asking about country support rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `country_support` with no surrounding whitespace.
+
+### 26. `declined_card_payment`
+**Description:** The user is asking about declined card payment. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about declined card payment.
+  - Can you help me figure out declined card payment?
+**Disambiguation:** Most often confused with: `declined_cash_withdrawal`, `declined_transfer`, `card_not_working`. Prefer this label only when the user is specifically asking about declined card payment rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `declined_card_payment` with no surrounding whitespace.
+
+### 27. `declined_cash_withdrawal`
+**Description:** The user is asking about declined cash withdrawal. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about declined cash withdrawal.
+  - Can you help me figure out declined cash withdrawal?
+**Disambiguation:** Most often confused with: `declined_card_payment`, `card_swallowed`, `atm_support`. Prefer this label only when the user is specifically asking about declined cash withdrawal rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `declined_cash_withdrawal` with no surrounding whitespace.
+
+### 28. `declined_transfer`
+**Description:** The user is asking about declined transfer. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about declined transfer.
+  - Can you help me figure out declined transfer?
+**Disambiguation:** Most often confused with: `failed_transfer`, `cancel_transfer`, `declined_card_payment`. Prefer this label only when the user is specifically asking about declined transfer rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `declined_transfer` with no surrounding whitespace.
+
+### 29. `direct_debit_payment_not_recognised`
+**Description:** The user is asking about direct debit payment not recognised. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about direct debit payment not recognised.
+  - Can you help me figure out direct debit payment not recognised?
+**Disambiguation:** Most often confused with: `card_payment_not_recognised`, `transaction_charged_twice`. Prefer this label only when the user is specifically asking about direct debit payment not recognised rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `direct_debit_payment_not_recognised` with no surrounding whitespace.
+
+### 30. `disposable_card_limits`
+**Description:** The user is asking about disposable card limits. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about disposable card limits.
+  - Can you help me figure out disposable card limits?
+**Disambiguation:** Most often confused with: `get_disposable_virtual_card`, `top_up_limits`. Prefer this label only when the user is specifically asking about disposable card limits rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `disposable_card_limits` with no surrounding whitespace.
+
+### 31. `edit_personal_details`
+**Description:** The user is asking about edit personal details. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about edit personal details.
+  - Can you help me figure out edit personal details?
+**Disambiguation:** Most often confused with: `verify_my_identity`. Prefer this label only when the user is specifically asking about edit personal details rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `edit_personal_details` with no surrounding whitespace.
+
+### 32. `exchange_charge`
+**Description:** The user is asking about exchange charge. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about exchange charge.
+  - Can you help me figure out exchange charge?
+**Disambiguation:** Most often confused with: `exchange_rate`, `card_payment_fee_charged`. Prefer this label only when the user is specifically asking about exchange charge rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `exchange_charge` with no surrounding whitespace.
+
+### 33. `exchange_rate`
+**Description:** The user is asking about exchange rate. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about exchange rate.
+  - Can you help me figure out exchange rate?
+**Disambiguation:** Most often confused with: `card_payment_wrong_exchange_rate`, `exchange_charge`, `exchange_via_app`. Prefer this label only when the user is specifically asking about exchange rate rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `exchange_rate` with no surrounding whitespace.
+
+### 34. `exchange_via_app`
+**Description:** The user is asking about exchange via app. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about exchange via app.
+  - Can you help me figure out exchange via app?
+**Disambiguation:** Most often confused with: `exchange_rate`, `exchange_charge`. Prefer this label only when the user is specifically asking about exchange via app rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `exchange_via_app` with no surrounding whitespace.
+
+### 35. `extra_charge_on_statement`
+**Description:** The user is asking about extra charge on statement. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about extra charge on statement.
+  - Can you help me figure out extra charge on statement?
+**Disambiguation:** Most often confused with: `card_payment_fee_charged`, `transfer_fee_charged`, `transaction_charged_twice`. Prefer this label only when the user is specifically asking about extra charge on statement rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `extra_charge_on_statement` with no surrounding whitespace.
+
+### 36. `failed_transfer`
+**Description:** The user is asking about failed transfer. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about failed transfer.
+  - Can you help me figure out failed transfer?
+**Disambiguation:** Most often confused with: `declined_transfer`, `transfer_not_received_by_recipient`, `cancel_transfer`. Prefer this label only when the user is specifically asking about failed transfer rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `failed_transfer` with no surrounding whitespace.
+
+### 37. `fiat_currency_support`
+**Description:** The user is asking about fiat currency support. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about fiat currency support.
+  - Can you help me figure out fiat currency support?
+**Disambiguation:** Most often confused with: `supported_cards_and_currencies`, `exchange_rate`. Prefer this label only when the user is specifically asking about fiat currency support rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `fiat_currency_support` with no surrounding whitespace.
+
+### 38. `get_disposable_virtual_card`
+**Description:** The user is asking about get disposable virtual card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about get disposable virtual card.
+  - Can you help me figure out get disposable virtual card?
+**Disambiguation:** Most often confused with: `getting_virtual_card`, `disposable_card_limits`. Prefer this label only when the user is specifically asking about get disposable virtual card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `get_disposable_virtual_card` with no surrounding whitespace.
+
+### 39. `get_physical_card`
+**Description:** The user is asking about get physical card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about get physical card.
+  - Can you help me figure out get physical card?
+**Disambiguation:** Most often confused with: `order_physical_card`, `getting_spare_card`. Prefer this label only when the user is specifically asking about get physical card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `get_physical_card` with no surrounding whitespace.
+
+### 40. `getting_spare_card`
+**Description:** The user is asking about getting spare card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about getting spare card.
+  - Can you help me figure out getting spare card?
+**Disambiguation:** Most often confused with: `order_physical_card`, `get_physical_card`. Prefer this label only when the user is specifically asking about getting spare card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `getting_spare_card` with no surrounding whitespace.
+
+### 41. `getting_virtual_card`
+**Description:** The user is asking about getting virtual card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about getting virtual card.
+  - Can you help me figure out getting virtual card?
+**Disambiguation:** Most often confused with: `get_disposable_virtual_card`, `virtual_card_not_working`. Prefer this label only when the user is specifically asking about getting virtual card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `getting_virtual_card` with no surrounding whitespace.
+
+### 42. `lost_or_stolen_card`
+**Description:** The user is asking about lost or stolen card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about lost or stolen card.
+  - Can you help me figure out lost or stolen card?
+**Disambiguation:** Most often confused with: `compromised_card`, `card_swallowed`, `lost_or_stolen_phone`. Prefer this label only when the user is specifically asking about lost or stolen card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `lost_or_stolen_card` with no surrounding whitespace.
+
+### 43. `lost_or_stolen_phone`
+**Description:** The user is asking about lost or stolen phone. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about lost or stolen phone.
+  - Can you help me figure out lost or stolen phone?
+**Disambiguation:** Most often confused with: `lost_or_stolen_card`. Prefer this label only when the user is specifically asking about lost or stolen phone rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `lost_or_stolen_phone` with no surrounding whitespace.
+
+### 44. `order_physical_card`
+**Description:** The user is asking about order physical card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about order physical card.
+  - Can you help me figure out order physical card?
+**Disambiguation:** Most often confused with: `get_physical_card`, `card_arrival`, `getting_spare_card`. Prefer this label only when the user is specifically asking about order physical card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `order_physical_card` with no surrounding whitespace.
+
+### 45. `passcode_forgotten`
+**Description:** The user is asking about passcode forgotten. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about passcode forgotten.
+  - Can you help me figure out passcode forgotten?
+**Disambiguation:** Most often confused with: `change_pin`, `pin_blocked`. Prefer this label only when the user is specifically asking about passcode forgotten rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `passcode_forgotten` with no surrounding whitespace.
+
+### 46. `pending_card_payment`
+**Description:** The user is asking about pending card payment. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about pending card payment.
+  - Can you help me figure out pending card payment?
+**Disambiguation:** Most often confused with: `pending_cash_withdrawal`, `pending_transfer`, `pending_top_up`. Prefer this label only when the user is specifically asking about pending card payment rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `pending_card_payment` with no surrounding whitespace.
+
+### 47. `pending_cash_withdrawal`
+**Description:** The user is asking about pending cash withdrawal. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about pending cash withdrawal.
+  - Can you help me figure out pending cash withdrawal?
+**Disambiguation:** Most often confused with: `pending_card_payment`, `declined_cash_withdrawal`. Prefer this label only when the user is specifically asking about pending cash withdrawal rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `pending_cash_withdrawal` with no surrounding whitespace.
+
+### 48. `pending_top_up`
+**Description:** The user is asking about pending top up. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about pending top up.
+  - Can you help me figure out pending top up?
+**Disambiguation:** Most often confused with: `top_up_failed`, `topping_up_by_card`, `pending_card_payment`. Prefer this label only when the user is specifically asking about pending top up rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `pending_top_up` with no surrounding whitespace.
+
+### 49. `pending_transfer`
+**Description:** The user is asking about pending transfer. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about pending transfer.
+  - Can you help me figure out pending transfer?
+**Disambiguation:** Most often confused with: `pending_card_payment`, `transfer_timing`, `failed_transfer`. Prefer this label only when the user is specifically asking about pending transfer rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `pending_transfer` with no surrounding whitespace.
+
+### 50. `pin_blocked`
+**Description:** The user is asking about PIN blocked. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about PIN blocked.
+  - Can you help me figure out PIN blocked?
+**Disambiguation:** Most often confused with: `change_pin`, `passcode_forgotten`, `card_swallowed`. Prefer this label only when the user is specifically asking about PIN blocked rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `pin_blocked` with no surrounding whitespace.
+
+### 51. `receiving_money`
+**Description:** The user is asking about receiving money. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about receiving money.
+  - Can you help me figure out receiving money?
+**Disambiguation:** Most often confused with: `transfer_into_account`, `balance_not_updated_after_bank_transfer`. Prefer this label only when the user is specifically asking about receiving money rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `receiving_money` with no surrounding whitespace.
+
+### 52. `Refund_not_showing_up`
+**Description:** The user is asking about a refund not appearing. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about a refund not appearing.
+  - Can you help me figure out a refund not appearing?
+**Disambiguation:** Most often confused with: `request_refund`, `reverted_card_payment?`. Prefer this label only when the user is specifically asking about a refund not appearing rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `Refund_not_showing_up` with no surrounding whitespace.
+
+### 53. `request_refund`
+**Description:** The user is asking about request refund. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about request refund.
+  - Can you help me figure out request refund?
+**Disambiguation:** Most often confused with: `Refund_not_showing_up`, `reverted_card_payment?`. Prefer this label only when the user is specifically asking about request refund rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `request_refund` with no surrounding whitespace.
+
+### 54. `reverted_card_payment?`
+**Description:** The user is asking about reverted card payment. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about reverted card payment.
+  - Can you help me figure out reverted card payment?
+**Disambiguation:** Most often confused with: `request_refund`, `Refund_not_showing_up`, `card_payment_not_recognised`. Prefer this label only when the user is specifically asking about reverted card payment rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `reverted_card_payment?` with no surrounding whitespace.
+
+### 55. `supported_cards_and_currencies`
+**Description:** The user is asking about supported cards and currencies. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about supported cards and currencies.
+  - Can you help me figure out supported cards and currencies?
+**Disambiguation:** Most often confused with: `fiat_currency_support`, `visa_or_mastercard`, `card_acceptance`. Prefer this label only when the user is specifically asking about supported cards and currencies rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `supported_cards_and_currencies` with no surrounding whitespace.
+
+### 56. `terminate_account`
+**Description:** The user is asking about terminate account. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about terminate account.
+  - Can you help me figure out terminate account?
+**Disambiguation:** Most often confused with: `edit_personal_details`. Prefer this label only when the user is specifically asking about terminate account rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `terminate_account` with no surrounding whitespace.
+
+### 57. `top_up_by_bank_transfer_charge`
+**Description:** The user is asking about top up by bank transfer charge. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about top up by bank transfer charge.
+  - Can you help me figure out top up by bank transfer charge?
+**Disambiguation:** Most often confused with: `top_up_by_card_charge`, `transfer_fee_charged`. Prefer this label only when the user is specifically asking about top up by bank transfer charge rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `top_up_by_bank_transfer_charge` with no surrounding whitespace.
+
+### 58. `top_up_by_card_charge`
+**Description:** The user is asking about top up by card charge. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about top up by card charge.
+  - Can you help me figure out top up by card charge?
+**Disambiguation:** Most often confused with: `top_up_by_bank_transfer_charge`, `topping_up_by_card`, `card_payment_fee_charged`. Prefer this label only when the user is specifically asking about top up by card charge rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `top_up_by_card_charge` with no surrounding whitespace.
+
+### 59. `top_up_by_cash_or_cheque`
+**Description:** The user is asking about top up by cash or cheque. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about top up by cash or cheque.
+  - Can you help me figure out top up by cash or cheque?
+**Disambiguation:** Most often confused with: `balance_not_updated_after_cheque_or_cash_deposit`. Prefer this label only when the user is specifically asking about top up by cash or cheque rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `top_up_by_cash_or_cheque` with no surrounding whitespace.
+
+### 60. `top_up_failed`
+**Description:** The user is asking about top up failed. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about top up failed.
+  - Can you help me figure out top up failed?
+**Disambiguation:** Most often confused with: `pending_top_up`, `topping_up_by_card`, `top_up_reverted`. Prefer this label only when the user is specifically asking about top up failed rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `top_up_failed` with no surrounding whitespace.
+
+### 61. `top_up_limits`
+**Description:** The user is asking about top up limits. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about top up limits.
+  - Can you help me figure out top up limits?
+**Disambiguation:** Most often confused with: `disposable_card_limits`, `top_up_failed`. Prefer this label only when the user is specifically asking about top up limits rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `top_up_limits` with no surrounding whitespace.
+
+### 62. `top_up_reverted`
+**Description:** The user is asking about top up reverted. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about top up reverted.
+  - Can you help me figure out top up reverted?
+**Disambiguation:** Most often confused with: `top_up_failed`, `topping_up_by_card`. Prefer this label only when the user is specifically asking about top up reverted rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `top_up_reverted` with no surrounding whitespace.
+
+### 63. `topping_up_by_card`
+**Description:** The user is asking about topPINg up by card. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about topPINg up by card.
+  - Can you help me figure out topPINg up by card?
+**Disambiguation:** Most often confused with: `top_up_by_card_charge`, `automatic_top_up`, `top_up_failed`. Prefer this label only when the user is specifically asking about topPINg up by card rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `topping_up_by_card` with no surrounding whitespace.
+
+### 64. `transaction_charged_twice`
+**Description:** The user is asking about transaction charged twice. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about transaction charged twice.
+  - Can you help me figure out transaction charged twice?
+**Disambiguation:** Most often confused with: `card_payment_not_recognised`, `extra_charge_on_statement`. Prefer this label only when the user is specifically asking about transaction charged twice rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `transaction_charged_twice` with no surrounding whitespace.
+
+### 65. `transfer_fee_charged`
+**Description:** The user is asking about transfer fee charged. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about transfer fee charged.
+  - Can you help me figure out transfer fee charged?
+**Disambiguation:** Most often confused with: `card_payment_fee_charged`, `exchange_charge`, `extra_charge_on_statement`. Prefer this label only when the user is specifically asking about transfer fee charged rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `transfer_fee_charged` with no surrounding whitespace.
+
+### 66. `transfer_into_account`
+**Description:** The user is asking about transfer into account. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about transfer into account.
+  - Can you help me figure out transfer into account?
+**Disambiguation:** Most often confused with: `receiving_money`, `balance_not_updated_after_bank_transfer`. Prefer this label only when the user is specifically asking about transfer into account rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `transfer_into_account` with no surrounding whitespace.
+
+### 67. `transfer_not_received_by_recipient`
+**Description:** The user is asking about transfer not received by recipient. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about transfer not received by recipient.
+  - Can you help me figure out transfer not received by recipient?
+**Disambiguation:** Most often confused with: `transfer_timing`, `failed_transfer`, `pending_transfer`. Prefer this label only when the user is specifically asking about transfer not received by recipient rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `transfer_not_received_by_recipient` with no surrounding whitespace.
+
+### 68. `transfer_timing`
+**Description:** The user is asking about transfer timing. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about transfer timing.
+  - Can you help me figure out transfer timing?
+**Disambiguation:** Most often confused with: `transfer_not_received_by_recipient`, `pending_transfer`. Prefer this label only when the user is specifically asking about transfer timing rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `transfer_timing` with no surrounding whitespace.
+
+### 69. `unable_to_verify_identity`
+**Description:** The user is asking about unable to verify identity. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about unable to verify identity.
+  - Can you help me figure out unable to verify identity?
+**Disambiguation:** Most often confused with: `verify_my_identity`, `why_verify_identity`. Prefer this label only when the user is specifically asking about unable to verify identity rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `unable_to_verify_identity` with no surrounding whitespace.
+
+### 70. `verify_my_identity`
+**Description:** The user is asking about verify my identity. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about verify my identity.
+  - Can you help me figure out verify my identity?
+**Disambiguation:** Most often confused with: `why_verify_identity`, `unable_to_verify_identity`, `verify_source_of_funds`. Prefer this label only when the user is specifically asking about verify my identity rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `verify_my_identity` with no surrounding whitespace.
+
+### 71. `verify_source_of_funds`
+**Description:** The user is asking about verify source of funds. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about verify source of funds.
+  - Can you help me figure out verify source of funds?
+**Disambiguation:** Most often confused with: `verify_my_identity`, `why_verify_identity`. Prefer this label only when the user is specifically asking about verify source of funds rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `verify_source_of_funds` with no surrounding whitespace.
+
+### 72. `verify_top_up`
+**Description:** The user is asking about verify top up. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about verify top up.
+  - Can you help me figure out verify top up?
+**Disambiguation:** Most often confused with: `pending_top_up`, `verify_my_identity`. Prefer this label only when the user is specifically asking about verify top up rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `verify_top_up` with no surrounding whitespace.
+
+### 73. `virtual_card_not_working`
+**Description:** The user is asking about virtual card not working. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about virtual card not working.
+  - Can you help me figure out virtual card not working?
+**Disambiguation:** Most often confused with: `card_not_working`, `getting_virtual_card`. Prefer this label only when the user is specifically asking about virtual card not working rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `virtual_card_not_working` with no surrounding whitespace.
+
+### 74. `visa_or_mastercard`
+**Description:** The user is asking about Visa or Mastercard. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about Visa or Mastercard.
+  - Can you help me figure out Visa or Mastercard?
+**Disambiguation:** Most often confused with: `supported_cards_and_currencies`, `card_acceptance`. Prefer this label only when the user is specifically asking about Visa or Mastercard rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `visa_or_mastercard` with no surrounding whitespace.
+
+### 75. `why_verify_identity`
+**Description:** The user is asking about why verify identity. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about why verify identity.
+  - Can you help me figure out why verify identity?
+**Disambiguation:** Most often confused with: `verify_my_identity`, `verify_source_of_funds`. Prefer this label only when the user is specifically asking about why verify identity rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `why_verify_identity` with no surrounding whitespace.
+
+### 76. `wrong_amount_of_cash_received`
+**Description:** The user is asking about wrong amount of cash received. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about wrong amount of cash received.
+  - Can you help me figure out wrong amount of cash received?
+**Disambiguation:** Most often confused with: `cash_withdrawal_not_recognised`, `wrong_exchange_rate_for_cash_withdrawal`. Prefer this label only when the user is specifically asking about wrong amount of cash received rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `wrong_amount_of_cash_received` with no surrounding whitespace.
+
+### 77. `wrong_exchange_rate_for_cash_withdrawal`
+**Description:** The user is asking about wrong exchange rate for cash withdrawal. Use this intent only when the message clearly concerns this topic and not a related intent.
+**Typical phrasings:**
+  - I have a question about wrong exchange rate for cash withdrawal.
+  - Can you help me figure out wrong exchange rate for cash withdrawal?
+**Disambiguation:** Most often confused with: `exchange_rate`, `card_payment_wrong_exchange_rate`. Prefer this label only when the user is specifically asking about wrong exchange rate for cash withdrawal rather than one of the related concepts; when the user message clearly references a more specific neighbour intent, choose that one.
+**Output:** Emit the exact string `wrong_exchange_rate_for_cash_withdrawal` with no surrounding whitespace.
+
+
+## Frequently-Asked Questions (For Classifier Behaviour)
+
+**Q: What if the user message is in a non-English language?**
+A: This classifier is monolingual English. If the message is clearly not in
+English, attempt to translate the user's intent and apply the standard
+classification rules. Do not refuse the classification.
+
+**Q: What if the user message is gibberish or empty?**
+A: Apply the standard classification rules to the best of your ability.
+The classifier is not responsible for upstream input quality. Output the
+single most plausible intent label given the available signal.
+
+**Q: What if the user is angry or using profanity?**
+A: Tone is not signal for intent. Strip the affective content from the
+message and classify on the underlying request.
+
+**Q: What if the user is asking about something not in the 77 intents?**
+A: This is a closed taxonomy. Output the single most plausible intent
+label from the 77 even if no intent perfectly fits. Do not output a
+fallback "other" or "unknown" — those are not in the taxonomy.
+
+**Q: What if the user message contains multiple intents?**
+A: Apply the Primary Subject Only rule from the Operating Principles
+section. Identify the single primary intent and output only that label.
+
+## Common Classifier Mistakes (Anti-patterns to Avoid)
+
+The following are anti-patterns frequently observed in classifier outputs
+and are to be strictly avoided:
+
+  - **Outputting a paraphrase of a label.** Output `card_arrival`, not
+    `card has arrived` or `arrival of card`. The canonical label string
+    is the only acceptable output.
+
+  - **Outputting a label not in the taxonomy.** Even if a label seems
+    intuitively appropriate, only the 77 canonical labels are valid.
+    `card_status_check`, for example, is not a valid label.
+
+  - **Outputting multiple labels.** Output exactly one label.
+
+  - **Outputting JSON or structured output.** The contract is a single
+    plain-text label string per line.
+
+  - **Outputting commentary.** Do not output "I think the intent is..." or
+    "The user is asking about..." — output the bare label.
+
+  - **Outputting capitalization variants.** Match the canonical
+    capitalization exactly. `Refund_not_showing_up` is the only correct
+    capitalization for that intent.
+
+  - **Outputting label IDs or numbers.** Do not output an integer index
+    such as `42` — output the canonical string label.
+
+## Worked Examples
+
+Worked example 1.
+User message: "Hi there, my card hasn't arrived yet, it's been over a week now"
+Correct output: card_arrival
+
+Worked example 2.
+User message: "How do I get my new card to work? It just showed up in the mail"
+Correct output: activate_my_card
+
+Worked example 3.
+User message: "Why was I charged a fee on this card payment?"
+Correct output: card_payment_fee_charged
+
+Worked example 4.
+User message: "I lost my phone and I'm worried about my card"
+Correct output: lost_or_stolen_phone
+
+Worked example 5.
+User message: "The ATM didn't give me the right amount of cash"
+Correct output: wrong_amount_of_cash_received
+
+Worked example 6.
+User message: "I need to verify who I am, how do I do that?"
+Correct output: verify_my_identity
+
+Worked example 7.
+User message: "Can I add this card to Apple Pay?"
+Correct output: apple_pay_or_google_pay
+
+Worked example 8.
+User message: "I'd like to close my account"
+Correct output: terminate_account
+
+Worked example 9.
+User message: "My contactless isn't working anymore"
+Correct output: contactless_not_working
+
+Worked example 10.
+User message: "Can I send money internationally?"
+Correct output: country_support
+
+## Final Reminder
+
+Output exactly one of the 77 canonical labels. No commentary. No
+formatting. No additional whitespace. The downstream pipeline depends on
+strict format compliance.
+
+End of system prompt v3.7.
+"""
+# ---------------------------------------------------------------------------
+# END WECO-MUTABLE REGION
+# ---------------------------------------------------------------------------
+
+
+_client: OpenAI | None = None
+
+
+def _get_client() -> OpenAI:
+    global _client
+    if _client is None:
+        _client = OpenAI()
+    return _client
+
+
+def classify(query: str, model: str = "gpt-5-mini") -> str:
+    """Classify a single user query into one of the 77 BANKING77 intents.
+
+    Returns the model's raw text response. Label parsing happens in eval.py.
+    """
+    response = _get_client().chat.completions.create(
+        model=model,
+        messages=[{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": query}],
+        max_completion_tokens=256,
+        reasoning_effort="minimal",
+    )
+    return (response.choices[0].message.content or "").strip()

--- a/examples/prompt-compression/prompt_guide.md
+++ b/examples/prompt-compression/prompt_guide.md
@@ -1,0 +1,55 @@
+You are compressing a 65,887-character system prompt for a 77-class banking
+intent classifier. The accuracy of the classifier on a held-out 200-sample
+slice of PolyAI/banking77 is constrained by the eval — if accuracy drops below
+the baseline minus 2 percentage points, the metric is penalized by
++10,000,000 and the variant is discarded.
+
+Your goal is to **minimize the character count** of the SYSTEM_PROMPT string
+in optimize.py while keeping accuracy above the threshold.
+
+Levers to try, ordered roughly from cheapest-wins to most-impactful:
+
+1. **Strip the verbose preamble.** The Operating Principles, Output Format
+   Specification, and Disambiguation Guidelines sections are heavily
+   redundant with the per-class blocks and with each other. Consolidate
+   into a single concise rule list.
+
+2. **Strip per-class fluff.** Each class block has a verbose Description,
+   Typical phrasings, Disambiguation, and Output requirement. The Output
+   requirement is identical across all 77 classes. Most Descriptions can
+   be reduced to the topic phrase. Most Typical phrasings can be cut
+   entirely — the LLM doesn't need example user utterances when the topic
+   is well-named.
+
+3. **Drop the FAQ and Common Mistakes sections.** They restate rules from
+   the preamble.
+
+4. **Drop or shorten the Worked Examples.** They demonstrate format
+   compliance, which the LLM already learns from the label list.
+
+5. **Compress the label list.** A bare enumeration of the 77 canonical
+   labels may be enough — the model can disambiguate from label names
+   alone for many of the 77 classes.
+
+6. **Reformat for density.** Trade markdown structure for compact list or
+   table format if it preserves accuracy.
+
+What you MUST preserve:
+
+- The exact 77 canonical label strings (case-sensitive, including
+  `Refund_not_showing_up` with capital R and `reverted_card_payment?` with
+  trailing question mark).
+- An instruction telling the model to output exactly one canonical label
+  string with no commentary.
+- The classify() function signature, the OpenAI call, and the surrounding
+  Python code outside the WECO-MUTABLE REGION markers.
+
+What you MUST NOT do:
+
+- Change the variable name `SYSTEM_PROMPT` or its assignment.
+- Modify any code outside the WECO-MUTABLE REGION markers in optimize.py.
+- Drop labels from the taxonomy (the eval will fail with parse errors).
+
+Iterate aggressively. Real production prompts of this shape compress
+80-95% with no accuracy loss; large jumps in a single mutation are
+expected and welcomed.


### PR DESCRIPTION
## Summary

New `examples/prompt-compression/` showing the *minimize-chars-with-accuracy-floor* shape of Weco optimization, complementing the *maximize-accuracy* shape in `examples/prompt/`.

The example deliberately bloats a BANKING77 classifier system prompt to 65,887 characters (mimicking real production prompt patterns: operating principles, per-class blocks, FAQ, worked examples), then has Weco compress it while constraining accuracy to stay at or above the baseline minus 2pp.

## Headline result

`claude-opus-4-7` × 50 steps: **65,887 → 3,229 chars (95.1% reduction)** holding accuracy at 0.7500 on a 200-sample BANKING77 test slice (baseline 0.7700, threshold 0.7500). `gpt-5.5` found a different plateau at 6,828 chars (89.6%).

See the trajectory: https://weco.ai/share/XSRQdS7vfMdt9beD3KR1tlhg7By-FFIo

## What's in the folder

| File | Purpose |
| :--- | :--- |
| `optimize.py` | Baked baseline + `classify(query, model)`. Weco mutates only the `SYSTEM_PROMPT` string in the marked WECO-MUTABLE REGION. |
| `eval.py` | 200 BANKING77 samples → emits `accuracy:`, `chars:`, `metric:`. |
| `labels.py` | 77 canonical labels + robust `parse_predicted_label()`. |
| `build_bloated_prompt.py` | Deterministic baseline generator. |
| `bake_optimize.py` | One-shot: writes `optimize.py` from the generator. |
| `measure_baseline.py` | Measures baseline accuracy → `baseline_accuracy.json`. |
| `prompt_guide.md` | `--additional-instructions` content for the optimizer. |
| `baseline_accuracy.json` | Pre-measured 0.7700 (gpt-5-mini, seed=0). |
| `README.md` | Setup + run + headline result + structure of the compressed prompt. |

Also updates `examples/README.md` to add this example to the table of contents, the at-a-glance table, and the quick-starts section.

## Note on the baseline

The 65K-char baseline is **synthetic** — generated to mimic real production classifier prompts at the same scale as a representative customer prompt. BANKING77 itself is real and public ([PolyAI/banking77](https://huggingface.co/datasets/PolyAI/banking77) on HuggingFace). The compression ratios match what we've seen on real customer prompts of similar size and shape.

## Test plan

- [x] Smoke-tested locally: `optimize.py` imports, all 77 labels round-trip through parser, `eval.py` imports and threshold loads from `baseline_accuracy.json`
- [x] Independent eval of the 3,229-char winner: accuracy=0.7500, parse_rate=1.0
- [ ] Reviewer: spot-check `weco run` end-to-end on a fresh checkout
