### PR TITLE
feat(cli): halt runs after N consecutive identical evaluation failures

### DIFF
--- a/tests/test_failure_streak.py
+++ b/tests/test_failure_streak.py
@@ -1,0 +1,85 @@
+"""Tests for the consecutive-identical-failures halt logic in run_optimization_loop."""
+
+from weco.optimizer import _extract_error_signature, _extract_error_tail
+
+
+# The actual term_out from a real failed run that surfaced this issue
+# (5-step run on Windows where every step failed because the eval command
+# `python evaluate.py` resolved to system Python, not the venv Python with sklearn).
+SKLEARN_MISSING_OUTPUT = """\
+Traceback (most recent call last):
+  File "C:\\Users\\jzyji\\AppData\\Local\\Temp\\weco-experiment\\evaluate.py", line 4, in <module>
+    from sklearn.datasets import load_breast_cancer
+ModuleNotFoundError: No module named 'sklearn'
+"""
+
+HEALTHY_OUTPUT = "accuracy: 0.9543\n"
+
+DIFFERENT_ERROR_OUTPUT = """\
+Traceback (most recent call last):
+  File "evaluate.py", line 12, in <module>
+    raise ValueError("Invalid input shape")
+ValueError: Invalid input shape
+"""
+
+
+class TestExtractErrorSignature:
+    def test_healthy_output_returns_none(self):
+        # A successful eval (just a metric line) is not an error
+        assert _extract_error_signature(HEALTHY_OUTPUT) is None
+
+    def test_empty_output_returns_none(self):
+        assert _extract_error_signature("") is None
+        assert _extract_error_signature("   \n   \n") is None
+
+    def test_traceback_returns_signature(self):
+        sig = _extract_error_signature(SKLEARN_MISSING_OUTPUT)
+        assert sig is not None
+        assert len(sig) == 40  # sha1 hex length
+
+    def test_identical_outputs_produce_identical_signatures(self):
+        sig1 = _extract_error_signature(SKLEARN_MISSING_OUTPUT)
+        sig2 = _extract_error_signature(SKLEARN_MISSING_OUTPUT)
+        assert sig1 == sig2
+
+    def test_different_errors_produce_different_signatures(self):
+        sig_sklearn = _extract_error_signature(SKLEARN_MISSING_OUTPUT)
+        sig_value = _extract_error_signature(DIFFERENT_ERROR_OUTPUT)
+        assert sig_sklearn != sig_value
+
+    def test_signature_robust_to_leading_lines(self):
+        # If two outputs share the same trailing error but differ in earlier lines,
+        # they should still hash identically (because we hash the trailing lines).
+        with_preamble = (
+            "Step 3 of 5\n"
+            "Running evaluation...\n"
+            + SKLEARN_MISSING_OUTPUT
+        )
+        sig1 = _extract_error_signature(SKLEARN_MISSING_OUTPUT)
+        sig2 = _extract_error_signature(with_preamble)
+        assert sig1 == sig2
+
+    def test_error_indicators_picked_up(self):
+        # Any of the recognized indicators should trigger signature extraction
+        for indicator_output in [
+            "Traceback (most recent call last):\n  ...\nValueError: bad",
+            "Exception: something broke",
+            "ImportError: No module named 'x'",
+            "FATAL: cannot proceed",
+        ]:
+            assert _extract_error_signature(indicator_output) is not None
+
+
+class TestExtractErrorTail:
+    def test_returns_last_n_lines(self):
+        output = "line1\nline2\nline3\nline4\nline5\nline6\n"
+        tail = _extract_error_tail(output, max_lines=3)
+        assert tail == "line4\nline5\nline6"
+
+    def test_skips_blank_lines(self):
+        output = "line1\n\n\nline2\n\nline3\n"
+        tail = _extract_error_tail(output, max_lines=5)
+        assert "line1" in tail and "line2" in tail and "line3" in tail
+
+    def test_empty_output_returns_empty_string(self):
+        assert _extract_error_tail("") == ""

--- a/weco/cli.py
+++ b/weco/cli.py
@@ -176,6 +176,17 @@ Default models for providers:
         default=5,
         help="Max auto-resume attempts before giving up and printing the manual resume command (default: 5).",
     )
+    run_parser.add_argument(
+        "--max-identical-failures",
+        type=int,
+        default=3,
+        help=(
+            "Halt the run when this many consecutive steps fail with the same error "
+            "signature (e.g. the same ModuleNotFoundError repeating). Catches stuck "
+            "runs where the optimizer keeps proposing variants that can't possibly "
+            "succeed in the current environment. Default: 3. Set to 0 to disable."
+        ),
+    )
 
     # --- Eval backend integration ---
     run_parser.add_argument(
@@ -403,6 +414,15 @@ Supported provider names: {supported_providers}.
         default=5,
         help="Max auto-resume attempts before giving up and printing the manual resume command (default: 5).",
     )
+    resume_parser.add_argument(
+        "--max-identical-failures",
+        type=int,
+        default=3,
+        help=(
+            "Halt the run when this many consecutive steps fail with the same error "
+            "signature. Default: 3. Set to 0 to disable."
+        ),
+    )
 
 
 def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
@@ -559,6 +579,7 @@ def execute_run_command(args: argparse.Namespace) -> None:
         output_mode=args.output,
         submit_timeout=getattr(args, "submit_timeout", None),
         auto_resume_policy=auto_resume_policy,
+        max_identical_failures=getattr(args, "max_identical_failures", 3),
     )
 
     exit_code = 0 if success else 1
@@ -587,6 +608,7 @@ def execute_resume_command(args: argparse.Namespace) -> None:
         submit_timeout=getattr(args, "submit_timeout", None),
         auto_resume_policy=auto_resume_policy,
         additional_steps=args.steps,
+        max_identical_failures=getattr(args, "max_identical_failures", 3),
     )
 
     sys.exit(0 if success else 1)

--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -1,3 +1,4 @@
+import hashlib
 import math
 import os
 import pathlib
@@ -6,7 +7,7 @@ import threading
 import time
 import traceback
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from requests.exceptions import ConnectionError as RequestsConnectionError, HTTPError, ReadTimeout
 from rich.console import Console
@@ -64,6 +65,55 @@ _TRANSIENT_REASONS = frozenset({"transient_network_error", "http_502", "http_503
 
 def _is_transient(result: OptimizationResult) -> bool:
     return result.reason in _TRANSIENT_REASONS
+
+
+# Substrings that indicate the eval output contains a hard error rather than a
+# legitimate (low) metric value. Detection is intentionally lenient — any one of
+# these in the last few lines is enough.
+_ERROR_INDICATORS = (
+    "Traceback",
+    "Error:",
+    "Exception:",
+    "FATAL",
+    "ModuleNotFoundError",
+    "ImportError",
+    "SyntaxError",
+    "command not found",
+    "No such file or directory",
+)
+
+
+def _extract_error_signature(term_out: str) -> Optional[str]:
+    """Hash a stable signature of the error in eval output, or return None if no error.
+
+    Strategy: look at the last few non-empty lines (where most error messages land)
+    and hash them. Returns None when the output looks healthy (no error markers in
+    the trailing lines), which prevents the streak check from triggering on
+    successful-but-flat runs.
+    """
+    if not term_out:
+        return None
+    lines = [line.rstrip() for line in term_out.splitlines() if line.strip()]
+    if not lines:
+        return None
+    tail = lines[-5:]
+    tail_text = "\n".join(tail)
+    has_error = any(indicator in tail_text for indicator in _ERROR_INDICATORS)
+    if not has_error:
+        return None
+    # Hash the last 3 lines — robust to small variations like tracebacks with
+    # different intermediate frames, while still distinguishing different errors.
+    signature_lines = lines[-3:] if len(lines) >= 3 else lines
+    digest_input = "\n".join(signature_lines).encode("utf-8", errors="replace")
+    return hashlib.sha1(digest_input).hexdigest()
+
+
+def _extract_error_tail(term_out: str, max_lines: int = 5) -> str:
+    """Return the trailing lines of eval output for surfacing in error messages."""
+    if not term_out:
+        return ""
+    lines = [line.rstrip() for line in term_out.splitlines() if line.strip()]
+    return "\n".join(lines[-max_lines:])
 
 
 def _silent_resume(run_id: str, auth_headers: dict, api_keys: Optional[dict]) -> bool:
@@ -166,6 +216,7 @@ def run_optimization_loop(
     max_poll_attempts: int = 300,
     api_keys: Optional[dict] = None,
     submit_timeout: Optional[int] = None,
+    max_identical_failures: int = 3,
 ) -> OptimizationResult:
     """
     Shared queue-based execution loop for optimize and resume.
@@ -190,11 +241,17 @@ def run_optimization_loop(
         submit_timeout: Optional read-timeout override (seconds) for the
             ``/suggest`` call made when submitting a step's result. ``None``
             preserves the existing ~61-minute default.
+        max_identical_failures: Halt the run when this many consecutive steps
+            produce the same error signature in their eval output. Catches stuck
+            runs like environment misconfigurations where every step fails with
+            the same ``ModuleNotFoundError`` and the optimizer keeps proposing
+            variants that can't possibly succeed. ``0`` disables the check.
 
     Returns:
         OptimizationResult with success status and termination info.
     """
     step = start_step
+    recent_error_signatures: List[str] = []
 
     try:
         while True:
@@ -275,6 +332,39 @@ def run_optimization_loop(
                 artifacts.save_execution_output(step=step, output=term_out)
 
             ui.on_output(term_out)
+
+            # Track consecutive identical error signatures. When the eval output
+            # keeps reproducing the same hard error (environment misconfig, missing
+            # module, etc.), the optimizer's hypothesis space is irrelevant — halt
+            # rather than burn more credits on impossible-to-validate variants.
+            if max_identical_failures > 0:
+                signature = _extract_error_signature(term_out)
+                if signature is None:
+                    recent_error_signatures = []
+                else:
+                    recent_error_signatures.append(signature)
+                    if (
+                        len(recent_error_signatures) >= max_identical_failures
+                        and len(set(recent_error_signatures[-max_identical_failures:])) == 1
+                    ):
+                        error_tail = _extract_error_tail(term_out)
+                        ui.on_error(
+                            f"Halted: {max_identical_failures} consecutive steps failed with the same error. "
+                            f"Last error excerpt:\n{error_tail}\n\n"
+                            f"This usually means the eval command can't run in the current environment. "
+                            f"Common causes: missing dependencies, wrong Python interpreter, or a path issue. "
+                            f"Re-run with --max-identical-failures 0 to override this check."
+                        )
+                        return OptimizationResult(
+                            success=False,
+                            final_step=step + 1,
+                            status="error",
+                            reason="identical_failure_streak",
+                            details=(
+                                f"Halted after {max_identical_failures} consecutive identical "
+                                f"evaluation failures. Last error excerpt:\n{error_tail}"
+                            ),
+                        )
 
             # Submit result. HTTP errors (insufficient credits, candidate generation
             # failures, etc.) propagate and are handled centrally below so the real
@@ -408,6 +498,7 @@ def resume_optimization(
     submit_timeout: Optional[int] = None,
     auto_resume_policy: Optional[AutoResumePolicy] = None,
     additional_steps: Optional[int] = None,
+    max_identical_failures: int = 3,
 ) -> bool:
     """
     Resume an interrupted or completed run using the queue-based optimization loop.
@@ -580,6 +671,7 @@ def resume_optimization(
                     poll_interval=poll_interval,
                     api_keys=api_keys,
                     submit_timeout=submit_timeout,
+                    max_identical_failures=max_identical_failures,
                 )
 
             result = _run_loop_with_auto_resume(
@@ -651,6 +743,7 @@ def optimize(
     output_mode: str = "rich",
     submit_timeout: Optional[int] = None,
     auto_resume_policy: Optional[AutoResumePolicy] = None,
+    max_identical_failures: int = 3,
 ) -> bool:
     """
     Simplified queue-based optimization loop.
@@ -783,6 +876,7 @@ def optimize(
                     poll_interval=poll_interval,
                     api_keys=api_keys,
                     submit_timeout=submit_timeout,
+                    max_identical_failures=max_identical_failures,
                 )
 
             result = _run_loop_with_auto_resume(


### PR DESCRIPTION
## Summary

Adds `--max-identical-failures` (default 3, 0 to disable) — halts a run when the eval output keeps reproducing the same hard error across consecutive steps. Catches stuck runs where the environment can't possibly support the eval, but the optimizer keeps proposing variants and burning credits because the error class is invisible to it.

## The failure mode

Surfaced cold during a Windows persona walkthrough on 2026-05-23:
- Installed weco in a temp venv with `pip install weco`
- Project had its deps (sklearn) installed in the same venv
- `weco run --eval-command "python evaluate.py"` invoked whatever `python` resolves to via `PATH` — system Python, without the deps
- Every step failed identically with `ModuleNotFoundError: No module named 'sklearn'`
- Current behavior: optimizer kept proposing different sklearn-using variants for the full 5-step budget; was billed $0.07 for nothing
- New behavior: after 3 identical signatures, halt with a diagnostic pointing at the likely cause

The dashboard's Agent panel's `Failures` quick action correctly diagnoses this kind of streak post-hoc, but only after the user manually clicks it. Better to short-circuit the run.

## Implementation

- `_extract_error_signature(term_out)` hashes the trailing few lines of eval output IFF they contain error-indicator substrings (`Traceback`, `Error:`, `Exception:`, `ModuleNotFoundError`, etc.). Returns `None` on healthy output so streaks reset on partial recovery.
- `_extract_error_tail(term_out)` surfaces the trailing lines verbatim in the halt diagnostic.
- `run_optimization_loop` tracks signatures across steps. When the last N >= `max_identical_failures` are identical, return an `OptimizationResult(reason="identical_failure_streak")`.
- New CLI flag `--max-identical-failures` wired into both `weco run` and `weco resume`.

## Default rationale

`3` = first failure + 2 retries before halt. Conservative enough to allow legitimate course-correction; aggressive enough to cap waste at 3 steps instead of the full budget.

`0` disables (existing behavior). Users who want to push through with a known-bad eval (debugging, comparing against control) can opt out.

## Test plan

- [x] 10 new unit tests for `_extract_error_signature` and `_extract_error_tail`
- [x] All 115 existing tests pass
- [ ] CI passes
- [ ] Manual: re-run the breast-cancer-with-broken-env scenario; verify halt after 3 steps with the expected diagnostic

## Followup (not in this PR — proposed separately to `#product`)

A preflight check that detects the env-mismatch BEFORE step 1 would be the cleaner fix — this PR is the safety net for everything that slips through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)