### PR TITLE
Add Claude Code streaming support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,18 @@ description = "Documentation for `weco`, a CLI for using Weco AI's code optimize
 readme = "README.md"
 version = "0.3.35"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "requests",
     "rich",
+    "textual>=0.80",
     "packaging",
     "gitingest",
     "psutil",
     "langsmith>=0.3.0",
     "jupyter>=1.1.1",
+    "realtime>=2.29.0",
+    "claude-agent-sdk>=0.2.87",
 ]
 keywords = ["AI", "Code Optimization", "Code Generation"]
 classifiers = [

--- a/tests/test_derive_handler.py
+++ b/tests/test_derive_handler.py
@@ -1,11 +1,14 @@
 """Unit tests for the ``weco run derive`` command handler.
 
-Mocks every external boundary the handler touches (auth, HTTP client,
-optimization loop, heartbeat thread, browser, artifacts, prompts, UI
-classes) so the handler can be exercised end-to-end with no network, no
-auth, no LLM, and no real threads.
+Mocks every external boundary the handler touches (auth, HTTP client, the
+lineage consumer, the working-tree lock, browser, prompts) so the handler can
+be exercised end-to-end with no network, no auth, no LLM, and no real threads.
 
-Tests are organized by *what they verify*, not by historical bug reference.
+Deriving no longer drives its own optimization loop: it creates the run and
+hands it to the single lineage consumer (``run_lineage_loop``) behind the
+working-tree ``consumer_lock``. If a consumer already holds the lock, derive
+just enqueues the new run and returns. These tests verify that wiring.
+
 ``_resolve_step_to_node_id`` is unit-tested directly; the rest exercise
 ``derive.handle`` end-to-end via the ``patched`` fixture.
 """
@@ -19,7 +22,6 @@ import requests
 from rich.console import Console
 
 from weco.commands.run import derive
-from weco.optimizer import OptimizationResult
 
 
 # ---------------------------------------------------------------------------
@@ -92,50 +94,39 @@ def _call_handle(**overrides):
 def patched():
     """Patch every external boundary derive.handle touches.
 
-    Yields a ``SimpleNamespace`` of the most useful mock handles. Both UI
-    classes are configured so that ``with ui_instance as ui:`` yields the
-    same mock instance — that way ``ui.on_init(...)`` lands directly on
-    ``patched.plain_ui.on_init`` (or ``live_ui.on_init``) for inspection.
+    ``consumer_lock`` is patched to a context manager that yields ``True``
+    (lock acquired → this process consumes) by default; flip
+    ``patched.lock.return_value.__enter__.return_value = False`` to simulate a
+    consumer already draining the lineage. ``run_lineage_loop`` is patched and
+    returns ``True`` (success) by default.
     """
     with (
         patch("weco.commands.run.derive.handle_authentication", return_value=("api-key", {"Authorization": "Bearer t"})),
         patch("weco.commands.run.derive.WecoClient") as MockClient,
-        patch("weco.commands.run.derive.run_optimization_loop") as mock_loop,
-        patch("weco.heartbeat.HeartbeatSender"),
-        patch("weco.commands.run.derive.RunArtifacts") as mock_artifacts,
-        patch("weco.commands.run.derive.report_termination"),
-        patch("weco.commands.run.derive.offer_apply_best_solution") as mock_apply,
+        patch("weco.commands.run.derive.run_lineage_loop") as mock_loop,
+        patch("weco.commands.run.derive.consumer_lock") as MockLock,
+        # Without this the success path calls open_browser(dashboard_url) for
+        # real, popping a tab per test run. Bound so tests can assert which
+        # URL the tab would have opened.
+        patch("weco.commands.run.derive.open_browser") as mock_open_browser,
         patch("weco.commands.run.derive.Confirm") as MockConfirm,
-        patch("weco.commands.run.derive.LiveOptimizationUI") as MockLiveUI,
-        patch("weco.commands.run.derive.PlainOptimizationUI") as MockPlainUI,
     ):
-        # Defaults: loop succeeds, prompts say yes.
-        mock_loop.return_value = OptimizationResult(
-            success=True, final_step=2, status="completed", reason="completed_successfully"
-        )
+        # Defaults: lock free, consumer succeeds, prompts say yes.
+        mock_loop.return_value = True
         MockConfirm.ask.return_value = True
-
-        # Make `with ui as x:` yield the outer mock so ui.on_init calls land
-        # on the same object the test inspects.
-        for mock_ui_cls in (MockLiveUI, MockPlainUI):
-            mock_ui_cls.return_value.__enter__.return_value = mock_ui_cls.return_value
+        MockLock.return_value.__enter__.return_value = True
+        MockLock.return_value.__exit__.return_value = False
 
         client = MockClient.return_value
         client.derive_run.return_value = _fake_derive_response()
 
         yield SimpleNamespace(
-            client=client,
-            loop=mock_loop,
-            artifacts=mock_artifacts,
-            apply_best=mock_apply,
-            confirm=MockConfirm,
-            live_ui=MockLiveUI.return_value,
-            plain_ui=MockPlainUI.return_value,
+            client=client, loop=mock_loop, lock=MockLock, confirm=MockConfirm, open_browser=mock_open_browser
         )
 
 
 def _loop_kwargs(patched) -> dict:
-    """Pull the kwargs ``run_optimization_loop`` was called with."""
+    """Pull the kwargs ``run_lineage_loop`` was called with."""
     return patched.loop.call_args.kwargs
 
 
@@ -219,16 +210,17 @@ def test_from_step_wiring(patched, from_step, expected_derive_from, expects_look
 
 
 # ---------------------------------------------------------------------------
-# Loop configuration plumbing — values flow from response into the loop
+# Consumer configuration plumbing — values flow from response into the loop
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "loop_kwarg, expected", [("eval_command", "python test.py"), ("save_logs", True), ("eval_timeout", 600)]
+    "loop_kwarg, expected",
+    [("eval_command", "python test.py"), ("save_logs", True), ("eval_timeout", 600), ("log_dir", ".weco-runs")],
 )
-def test_loop_config_inherited_from_response(patched, loop_kwarg, expected):
-    """The loop receives its config from the derive response, not from
-    defaults or a follow-up GET."""
+def test_consumer_config_inherited_from_response(patched, loop_kwarg, expected):
+    """The lineage consumer receives its config from the derive response, not
+    from defaults or a follow-up GET."""
     _call_handle()
     assert _loop_kwargs(patched)[loop_kwarg] == expected
 
@@ -240,11 +232,11 @@ def test_eval_timeout_none_passes_through(patched):
     assert _loop_kwargs(patched)["eval_timeout"] is None
 
 
-def test_log_dir_inherited_from_response_into_artifacts(patched):
-    """log_dir doesn't go to the loop directly — it goes to RunArtifacts."""
+def test_consumer_scoped_to_lineage_not_run(patched):
+    """The consumer drains the whole lineage, so it is seeded with the
+    lineage_id — not the new run's id."""
     _call_handle()
-    patched.artifacts.assert_called_once()
-    assert patched.artifacts.call_args.kwargs["log_dir"] == ".weco-runs"
+    assert _loop_kwargs(patched)["lineage_id"] == "parent-id"
 
 
 def test_additional_instructions_flow_through_to_derive_run(patched):
@@ -260,7 +252,7 @@ def test_additional_instructions_flow_through_to_derive_run(patched):
 
 
 def test_originals_use_inherited_source_when_local_files_missing(patched, tmp_path, monkeypatch):
-    """If a file doesn't exist locally, the originals fed to the loop must
+    """If a file doesn't exist locally, the originals fed to the consumer must
     come from the inherited baseline — NEVER the candidate, which would
     pollute the working directory with generated code on every eval cycle."""
     monkeypatch.chdir(tmp_path)  # empty directory: no local files
@@ -270,8 +262,7 @@ def test_originals_use_inherited_source_when_local_files_missing(patched, tmp_pa
 
     _call_handle()
 
-    source_code = _loop_kwargs(patched)["source_code"]
-    assert source_code == {"main.py": "INHERITED"}
+    assert _loop_kwargs(patched)["originals"] == {"main.py": "INHERITED"}
 
 
 def test_originals_prefer_local_files_when_present(patched, tmp_path, monkeypatch):
@@ -283,59 +274,46 @@ def test_originals_prefer_local_files_when_present(patched, tmp_path, monkeypatc
 
     _call_handle()
 
-    assert _loop_kwargs(patched)["source_code"] == {"main.py": "LOCAL_EDITED"}
+    assert _loop_kwargs(patched)["originals"] == {"main.py": "LOCAL_EDITED"}
 
 
 # ---------------------------------------------------------------------------
-# UI dispatch: handler picks the right UI and routes derived_from via on_init
+# Attach-or-consume: a derive never starts a second consumer in one tree
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "output_mode, expected_ui, other_ui", [("plain", "plain_ui", "live_ui"), ("rich", "live_ui", "plain_ui")]
-)
-def test_handler_picks_ui_for_output_mode(patched, output_mode, expected_ui, other_ui):
-    """Plain mode constructs PlainOptimizationUI, rich mode constructs
-    LiveOptimizationUI. Each gets exactly one on_init call."""
-    _call_handle(output_mode=output_mode)
-    getattr(patched, expected_ui).on_init.assert_called_once()
-    getattr(patched, other_ui).on_init.assert_not_called()
+def test_consumes_when_lock_free(patched):
+    """With the working-tree lock free, derive becomes the lineage consumer."""
+    assert _call_handle() is True
+    patched.loop.assert_called_once()
 
 
-def test_on_init_receives_derived_from_payload(patched):
-    """The parent reference flows through on_init's payload unchanged — not
-    via a side-channel print or constructor argument.
+def test_attaches_without_consuming_when_lock_held(patched, capsys):
+    """If a consumer already holds the lock, derive must NOT start a second
+    loop (that would evaluate two candidates in one tree at once). It creates
+    the run, reports the attach, and returns True."""
+    patched.lock.return_value.__enter__.return_value = False  # held by another consumer
 
-    This is a *flow* test, not a value test: the assertion compares against
-    the same fixture constant (``_FAKE_DERIVED_FROM``) deliberately, to
-    verify pass-through of whatever the response contained. The specific
-    field values are an implementation detail of the fixture.
-    """
-    _call_handle()
-    assert patched.plain_ui.on_init.call_args.kwargs["derived_from"] == _FAKE_DERIVED_FROM
+    assert _call_handle() is True
 
-
-# ---------------------------------------------------------------------------
-# Exit code dispatch: handler return value reflects loop result
-# ---------------------------------------------------------------------------
+    patched.loop.assert_not_called()
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["run_id"] == "new-run-id"
+    assert payload["lineage_id"] == "parent-id"
+    assert payload["attached"] is True
 
 
-def test_handler_returns_false_when_loop_fails(patched):
-    """Failed loop must propagate as ``False`` — the dispatcher relies on
-    this to set the process exit code. Loop *success* is covered implicitly
-    by every other test in this file (the default fixture exercises it)."""
-    patched.loop.return_value = OptimizationResult(success=False, final_step=3, status="error", reason="submit_failed")
+def test_handler_returns_false_when_consumer_fails(patched):
+    """A failing consumer propagates as ``False`` — the dispatcher relies on
+    this to set the process exit code."""
+    patched.loop.return_value = False
     assert _call_handle() is False
 
 
 def test_handler_aborts_when_user_cancels_unchanged_files_prompt(patched):
-    """Rich mode prompts the user to confirm working-directory state. If
-    they say no, the handler aborts before starting the loop and returns
-    False without ever calling run_optimization_loop.
-
-    Verifies both that the prompt fired (so a future refactor that drops
-    the prompt entirely fails this test) and that the abort happens.
-    """
+    """Rich mode prompts the user to confirm working-directory state. If they
+    say no, the handler aborts before consuming and returns False without ever
+    acquiring the lock or starting the consumer."""
     patched.confirm.ask.return_value = False
     assert _call_handle(output_mode="rich") is False
     patched.confirm.ask.assert_called_once()
@@ -347,28 +325,6 @@ def test_plain_mode_skips_unchanged_files_prompt(patched):
     called. This is the positive form of the cancellation test above."""
     _call_handle(output_mode="plain")
     patched.confirm.ask.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Apply-best lifecycle: only after a successful loop
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "loop_success, expect_apply_called", [(True, True), (False, False)], ids=["success-applies-best", "failure-skips-apply"]
-)
-def test_apply_best_only_after_successful_loop(patched, loop_success, expect_apply_called):
-    patched.loop.return_value = OptimizationResult(
-        success=loop_success,
-        final_step=2,
-        status="completed" if loop_success else "error",
-        reason="completed_successfully" if loop_success else "submit_failed",
-    )
-    _call_handle()
-    if expect_apply_called:
-        patched.apply_best.assert_called_once()
-    else:
-        patched.apply_best.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -444,3 +400,28 @@ def test_handler_makes_one_derive_call_and_no_get_run_status(patched):
     _call_handle()
     patched.client.derive_run.assert_called_once()
     patched.client.get_run_status.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dashboard URL points at the lineage root, not the derived run
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_url_targets_lineage_root_not_derived_run(patched):
+    # Derived runs aren't standalone dashboard pages — the opened tab must
+    # be the lineage root (`lineage_id`), so the sub-run shows up under the
+    # root instead of as a dead-end tab on its own id.
+    _call_handle()
+    patched.open_browser.assert_called_once()
+    opened_url = patched.open_browser.call_args.args[0]
+    assert opened_url.endswith("/runs/parent-id")
+    assert "new-run-id" not in opened_url
+
+
+def test_dashboard_url_falls_back_to_run_id_without_lineage(patched):
+    # Defensive: if the response carries no lineage_id, fall back to the
+    # run's own id rather than producing a broken `/runs/None` link.
+    patched.client.derive_run.return_value = _fake_derive_response(lineage_id=None)
+    _call_handle()
+    opened_url = patched.open_browser.call_args.args[0]
+    assert opened_url.endswith("/runs/new-run-id")

--- a/tests/test_derive_request.py
+++ b/tests/test_derive_request.py
@@ -1,0 +1,40 @@
+from weco.commands.start.tui_bridge import build_derive_prompt, parse_derive_paths
+
+
+def test_parse_derive_paths_keeps_valid_entries_and_drops_garbage():
+    paths = parse_derive_paths(
+        {
+            "paths": [
+                {"node_id": "n1", "step": 4, "instructions": "  go fast  ", "steps": 25},
+                {"node_id": "n2", "steps": 0},
+                {"node_id": "n3", "steps": True},
+                {"node_id": ""},
+                {"instructions": "orphan"},
+                "not-a-dict",
+            ]
+        }
+    )
+    assert paths == [
+        {"node_id": "n1", "step": 4, "instructions": "go fast", "steps": 25},
+        {"node_id": "n2"},
+        {"node_id": "n3"},
+    ]
+
+
+def test_parse_derive_paths_handles_missing_or_malformed_list():
+    assert parse_derive_paths({}) == []
+    assert parse_derive_paths({"paths": "nope"}) == []
+
+
+def test_build_derive_prompt_emits_one_command_per_path_with_quoted_instructions():
+    prompt = build_derive_prompt("run-1", [{"node_id": "n1", "instructions": 'try "cuda" graphs'}, {"node_id": "n2"}])
+    assert "weco run derive run-1 --from-step n1 -i 'try \"cuda\" graphs' --output plain" in prompt
+    assert "weco run derive run-1 --from-step n2 --output plain" in prompt
+    assert "run_in_background" in prompt
+    assert "weco run status" in prompt
+
+
+def test_build_derive_prompt_passes_per_path_step_count():
+    prompt = build_derive_prompt("run-1", [{"node_id": "n1", "steps": 50}, {"node_id": "n2"}])
+    assert "weco run derive run-1 --from-step n1 -n 50 --output plain" in prompt
+    assert "weco run derive run-1 --from-step n2 --output plain" in prompt

--- a/tests/test_lineage_consumer.py
+++ b/tests/test_lineage_consumer.py
@@ -1,0 +1,130 @@
+"""Tests for the lineage consumer's poll-classification and exit behavior.
+
+The consumer must never mistake a failed/empty read for "the lineage is done"
+— that would orphan still-running runs. The decision is isolated in the pure
+``_classify_lineage_poll`` (unit-tested directly); ``run_lineage_loop`` is then
+exercised end-to-end to confirm it acts on those decisions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import weco.optimizer as opt
+from weco.optimizer import _PollAction, _classify_lineage_poll
+
+
+_AUTH = {"Authorization": "Bearer t"}
+
+
+# ---------------------------------------------------------------------------
+# Pure decision function
+# ---------------------------------------------------------------------------
+
+
+def test_failed_read_is_never_done():
+    # A read that didn't succeed says nothing about the lineage — keep waiting.
+    assert _classify_lineage_poll(read_ok=False, has_ready=False, active_run_count=None) is _PollAction.WAIT
+    assert _classify_lineage_poll(read_ok=False, has_ready=True, active_run_count=0) is _PollAction.WAIT
+
+
+def test_ready_work_is_processed():
+    # When there's work, the active count is irrelevant (and omitted by the server).
+    assert _classify_lineage_poll(read_ok=True, has_ready=True, active_run_count=None) is _PollAction.PROCESS
+
+
+def test_done_only_on_confirmed_empty_and_no_active_runs():
+    assert _classify_lineage_poll(read_ok=True, has_ready=False, active_run_count=0) is _PollAction.DONE
+
+
+def test_active_runs_without_work_keeps_waiting():
+    # A member between candidates (active, no ready task yet) is not "done".
+    assert _classify_lineage_poll(read_ok=True, has_ready=False, active_run_count=2) is _PollAction.WAIT
+
+
+def test_missing_active_count_does_not_guess_done():
+    # Server didn't report the count (e.g. version skew) — wait, don't assume done.
+    assert _classify_lineage_poll(read_ok=True, has_ready=False, active_run_count=None) is _PollAction.WAIT
+
+
+# ---------------------------------------------------------------------------
+# Loop behavior
+# ---------------------------------------------------------------------------
+
+
+def _result(*items, active=None):
+    """A successful lineage-queue read: given tasks plus an active-run count."""
+    return MagicMock(tasks=list(items), active_run_count=active)
+
+
+def _task(run_id="R", task_id="t1"):
+    return {"id": task_id, "run_id": run_id, "run": {"status": "running"}}
+
+
+def _run(loop_kwargs=None, *, get_tasks_side_effect, submit_return=None):
+    """Drive run_lineage_loop with every boundary mocked. Returns the mock
+    handles plus the loop's return value."""
+    state = {"ui": MagicMock(), "artifacts": MagicMock(), "step": 1, "done": False}
+    claimed = {"revision": {"code": {"main.py": "x"}, "plan": "p"}}
+
+    with (
+        patch("weco.optimizer.time.sleep"),
+        patch("weco.optimizer.LineageHeartbeatSender") as HB,
+        patch("weco.optimizer.get_lineage_execution_tasks", side_effect=get_tasks_side_effect) as get_tasks,
+        patch("weco.optimizer._build_run_state", return_value=state),
+        patch("weco.optimizer.claim_execution_task", return_value=claimed) as claim,
+        patch("weco.optimizer.run_evaluation_with_files_swap", return_value="out") as eval_swap,
+        patch("weco.optimizer.submit_execution_result", return_value=submit_return or {"is_done": False}) as submit,
+    ):
+        HB.return_value = MagicMock()
+        result = opt.run_lineage_loop(
+            lineage_id="L",
+            auth_headers=_AUTH,
+            originals={"main.py": "orig"},
+            eval_command="python e.py",
+            eval_timeout=None,
+            save_logs=False,
+            log_dir=".runs",
+            dashboard_base="http://d",
+            poll_interval=0,
+            **(loop_kwargs or {}),
+        )
+        return MagicMock(result=result, claim=claim, submit=submit, eval_swap=eval_swap, get_tasks=get_tasks)
+
+
+def test_transient_read_failure_does_not_orphan_a_ready_task():
+    """A failed poll (read returns None) must not be read as quiescence: the
+    consumer keeps going and still drains the task that appears next."""
+    h = _run(
+        # poll 1: read fails. poll 2: a ready task. poll 3: confirmed done.
+        get_tasks_side_effect=[None, _result(_task()), _result(active=0)]
+    )
+    h.claim.assert_called_once()
+    h.submit.assert_called_once()
+    assert h.result is True
+
+
+def test_exits_on_a_single_confirmed_done_poll():
+    """One authoritative read showing no work and no active runs is enough —
+    no arbitrary confirmation streak needed now that the count is consistent."""
+    h = _run(get_tasks_side_effect=[_result(active=0)])
+    h.claim.assert_not_called()
+    h.submit.assert_not_called()
+    assert h.get_tasks.call_count == 1
+    assert h.result is True
+
+
+def test_does_not_exit_while_a_run_is_active_with_no_tasks():
+    """An active member with no ready task (between candidates, or freshly
+    derived) keeps the consumer alive — up to the stuck backstop."""
+    h = _run({"max_idle_polls": 3}, get_tasks_side_effect=[_result(active=1)] * 10)
+    h.claim.assert_not_called()
+    assert h.get_tasks.call_count == 3  # waited, then bailed via backstop
+    assert h.result is True
+
+
+def test_repeated_read_failures_bail_via_backstop_without_orphaning():
+    """If the queue read keeps failing, the consumer waits (never declaring
+    done) and finally bails via the backstop rather than spinning forever."""
+    h = _run({"max_idle_polls": 2}, get_tasks_side_effect=[None] * 10)
+    h.claim.assert_not_called()
+    assert h.get_tasks.call_count == 2
+    assert h.result is True

--- a/tests/test_start_bridge_sdk.py
+++ b/tests/test_start_bridge_sdk.py
@@ -1,0 +1,569 @@
+"""Tests for the SDK-driven `weco start claude` bridge.
+
+Covers the parts we own: arg parsing, billing env construction, SDK message
+→ transcript envelope conversion, and the in-process approval router. The
+actual claude-agent-sdk call is faked so no network or claude binary is
+required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from weco.commands.start import tui_bridge as bridge, sdk_config, envelopes, approval_router
+
+
+# --- Arg parsing ---------------------------------------------------------------
+
+
+def test_parse_claude_args_extracts_model_and_effort():
+    parsed, extra = sdk_config.parse_claude_args(["--model", "opus", "--effort", "high"])
+    assert parsed == {"model": "opus", "effort": "high"}
+    assert extra == {}
+
+
+def test_parse_claude_args_pulls_dangerously_skip_permissions_flag():
+    parsed, _ = sdk_config.parse_claude_args(["--dangerously-skip-permissions"])
+    assert parsed.get("dangerously_skip_permissions") is True
+
+
+def test_parse_claude_args_forwards_unknown_flags_via_extra_args():
+    parsed, extra = sdk_config.parse_claude_args(["--add-dir", "/tmp/foo", "--debug", "--betas", "context-1m-2025-08-07"])
+    assert "add-dir" in extra
+    assert extra["add-dir"] == "/tmp/foo"
+    assert "debug" in extra  # bare flag → None
+    assert extra["debug"] is None
+    assert extra["betas"] == "context-1m-2025-08-07"
+    # Recognised structured fields are untouched here.
+    assert parsed == {}
+
+
+def test_parse_claude_args_handles_equals_form():
+    _, extra = sdk_config.parse_claude_args(["--add-dir=/tmp/x"])
+    assert extra == {"add-dir": "/tmp/x"}
+
+
+# --- Billing env --------------------------------------------------------------
+
+
+def test_build_sdk_env_weco_billing_encodes_session_id_in_base_url():
+    """The Anthropic SDK doesn't honor any "custom headers" env var, so we
+    smuggle the agent session id through the BASE_URL path itself. The
+    proxy reads it from `/anthropic/s/<id>/v1/messages` and uses it to
+    broadcast credits_updated events to the right channel."""
+    env = sdk_config.build_sdk_env(
+        billing="weco", api_key="weco-key-abc", weco_api_base="https://api.weco.ai/v1", session_id="sess-123"
+    )
+    assert env["ANTHROPIC_BASE_URL"] == "https://api.weco.ai/v1/llm/anthropic/s/sess-123"
+    assert env["ANTHROPIC_API_KEY"] == "weco-key-abc"
+
+
+def test_build_sdk_env_weco_billing_without_session_uses_anonymous_route():
+    """If we don't have a session id (channel setup failed, etc.) the
+    base URL falls back to the anonymous variant — calls still get billed,
+    they just won't trigger credits_updated broadcasts."""
+    env = sdk_config.build_sdk_env(
+        billing="weco", api_key="weco-key-abc", weco_api_base="https://api.weco.ai/v1", session_id=None
+    )
+    assert env["ANTHROPIC_BASE_URL"] == "https://api.weco.ai/v1/llm/anthropic"
+
+
+def test_build_sdk_env_claude_billing_leaves_anthropic_env_alone():
+    env = sdk_config.build_sdk_env(
+        billing="claude", api_key="weco-key-abc", weco_api_base="https://api.weco.ai/v1", session_id="sess-123"
+    )
+    # We must not have set anything anthropic-related when the user is on
+    # local OAuth or BYO API key — those flows would be hijacked otherwise.
+    assert "weco" not in (env.get("ANTHROPIC_BASE_URL") or "")
+
+
+def test_build_sdk_env_strips_trailing_slash_from_base():
+    env = sdk_config.build_sdk_env(billing="weco", api_key="k", weco_api_base="https://api.weco.ai/v1/", session_id="s")
+    assert env["ANTHROPIC_BASE_URL"] == "https://api.weco.ai/v1/llm/anthropic/s/s"
+
+
+# --- Envelope conversion (SDK message → claude stream-json shape) ------------
+
+
+def test_envelope_for_assistant_message_emits_assistant_event():
+    from claude_agent_sdk.types import AssistantMessage, TextBlock, ToolUseBlock
+
+    msg = AssistantMessage(
+        content=[TextBlock(text="Hello!"), ToolUseBlock(id="tu_1", name="Bash", input={"command": "ls"})],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+        error=None,
+        usage=None,
+        message_id="m1",
+        stop_reason=None,
+        session_id="s1",
+        uuid=None,
+    )
+
+    env = envelopes.envelope_for(msg)
+
+    assert env is not None
+    assert env["type"] == "assistant"
+    assert env["model"] == "claude-opus-4-7"
+    content = env["message"]["content"]
+    assert content[0] == {"type": "text", "text": "Hello!"}
+    assert content[1]["type"] == "tool_use"
+    assert content[1]["name"] == "Bash"
+    assert content[1]["input"] == {"command": "ls"}
+
+
+def test_envelope_for_includes_thinking_blocks_for_reasoning_dashboard():
+    from claude_agent_sdk.types import AssistantMessage, ThinkingBlock
+
+    msg = AssistantMessage(
+        content=[ThinkingBlock(thinking="reasoning text", signature="sig")],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+        error=None,
+        usage=None,
+        message_id="m1",
+        stop_reason=None,
+        session_id="s1",
+        uuid=None,
+    )
+    env = envelopes.envelope_for(msg)
+    assert env["message"]["content"][0]["type"] == "thinking"
+    assert env["message"]["content"][0]["thinking"] == "reasoning text"
+
+
+def test_envelope_for_result_message_emits_result_event_with_cost():
+    from claude_agent_sdk.types import ResultMessage
+
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=1234,
+        duration_api_ms=1100,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        stop_reason="end_turn",
+        total_cost_usd=0.04,
+        usage={"input_tokens": 100},
+        result="ok",
+        structured_output=None,
+        model_usage=None,
+        permission_denials=None,
+        deferred_tool_use=None,
+        errors=None,
+        api_error_status=None,
+        uuid=None,
+    )
+    env = envelopes.envelope_for(msg)
+    assert env["type"] == "result"
+    assert env["total_cost_usd"] == 0.04
+    assert env["duration_ms"] == 1234
+
+
+def test_envelope_for_unknown_message_type_returns_none():
+    assert envelopes.envelope_for(SimpleNamespace(type="weird")) is None
+
+
+# --- Approval router -----------------------------------------------------------
+
+
+def _queue_publish(q: "asyncio.Queue"):
+    """A publish fn that drains into a queue so tests can read what the router
+    broadcast. Returns True (published) like a real, non-full session would."""
+
+    def publish(line: str) -> bool:
+        q.put_nowait(line)
+        return True
+
+    return publish
+
+
+def test_approval_router_forwards_request_and_awaits_response():
+    asyncio.run(_approval_router_forwards_request_and_awaits_response())
+
+
+async def _approval_router_forwards_request_and_awaits_response():
+    outbound: asyncio.Queue = asyncio.Queue()
+    router = approval_router.ApprovalRouter(publish=_queue_publish(outbound))
+
+    ctx = SimpleNamespace(tool_use_id="tu_42")
+
+    async def caller():
+        return await router.can_use_tool("Bash", {"command": "ls"}, ctx)
+
+    task = asyncio.create_task(caller())
+    # The router should have published an approval_request envelope.
+    raw = await asyncio.wait_for(outbound.get(), timeout=1.0)
+    env = json.loads(raw)
+    assert env["type"] == "_weco_meta"
+    assert env["event"] == "approval_request"
+    assert env["id"] == "tu_42"
+    assert env["tool_name"] == "Bash"
+    assert env["summary"] == "ls"
+
+    # Simulate the dashboard responding.
+    router.resolve("tu_42", "approve", "once")
+    result = await asyncio.wait_for(task, timeout=1.0)
+    from claude_agent_sdk.types import PermissionResultAllow
+
+    assert isinstance(result, PermissionResultAllow)
+
+
+def test_approval_router_caches_tool_scope_approvals():
+    asyncio.run(_approval_router_caches_tool_scope_approvals())
+
+
+async def _approval_router_caches_tool_scope_approvals():
+    outbound: asyncio.Queue = asyncio.Queue()
+    router = approval_router.ApprovalRouter(publish=_queue_publish(outbound))
+    ctx = SimpleNamespace(tool_use_id="tu_1")
+
+    task = asyncio.create_task(router.can_use_tool("Read", {"file_path": "a.py"}, ctx))
+    await outbound.get()
+    router.resolve("tu_1", "approve", "tool")
+    await task
+
+    # Second call to the same tool with a different file → no new dashboard
+    # request, immediate allow from the cache.
+    ctx2 = SimpleNamespace(tool_use_id="tu_2")
+    result = await router.can_use_tool("Read", {"file_path": "b.py"}, ctx2)
+    from claude_agent_sdk.types import PermissionResultAllow
+
+    assert isinstance(result, PermissionResultAllow)
+    # No additional outbound message was produced.
+    assert outbound.empty()
+
+
+def test_approval_router_deny_returns_deny_result():
+    asyncio.run(_approval_router_deny_returns_deny_result())
+
+
+async def _approval_router_deny_returns_deny_result():
+    outbound: asyncio.Queue = asyncio.Queue()
+    router = approval_router.ApprovalRouter(publish=_queue_publish(outbound))
+    ctx = SimpleNamespace(tool_use_id="tu_99")
+
+    task = asyncio.create_task(router.can_use_tool("Bash", {"command": "rm -rf /"}, ctx))
+    await outbound.get()
+    router.resolve("tu_99", "deny", "once")
+    result = await task
+    from claude_agent_sdk.types import PermissionResultDeny
+
+    assert isinstance(result, PermissionResultDeny)
+
+
+def test_approval_router_command_scope_caches_exact_call():
+    asyncio.run(_approval_router_command_scope_caches_exact_call())
+
+
+async def _approval_router_command_scope_caches_exact_call():
+    outbound: asyncio.Queue = asyncio.Queue()
+    router = approval_router.ApprovalRouter(publish=_queue_publish(outbound))
+    ctx = SimpleNamespace(tool_use_id="tu_a")
+
+    task = asyncio.create_task(router.can_use_tool("Bash", {"command": "git status"}, ctx))
+    await outbound.get()
+    router.resolve("tu_a", "approve", "command")
+    await task
+
+    # Same exact command — cached.
+    result = await router.can_use_tool("Bash", {"command": "git status"}, SimpleNamespace(tool_use_id="tu_b"))
+    from claude_agent_sdk.types import PermissionResultAllow
+
+    assert isinstance(result, PermissionResultAllow)
+    assert outbound.empty()
+
+    # Different command — must round-trip.
+    task2 = asyncio.create_task(router.can_use_tool("Bash", {"command": "git log"}, SimpleNamespace(tool_use_id="tu_c")))
+    raw = await asyncio.wait_for(outbound.get(), timeout=1.0)
+    assert json.loads(raw)["event"] == "approval_request"
+    router.resolve("tu_c", "approve", "once")
+    await task2
+
+
+# --- AskUserQuestion routing ---------------------------------------------------
+
+
+def test_ask_user_question_forwards_request_and_returns_answers():
+    asyncio.run(_ask_user_question_forwards())
+
+
+async def _ask_user_question_forwards():
+    outbound: asyncio.Queue = asyncio.Queue()
+    router = approval_router.ApprovalRouter(publish=_queue_publish(outbound))
+    ctx = SimpleNamespace(tool_use_id="q_1")
+
+    questions = [
+        {
+            "question": "Which DB?",
+            "header": "DB",
+            "options": [{"label": "Postgres", "description": "Default"}, {"label": "SQLite", "description": "Local dev"}],
+            "multiSelect": False,
+        }
+    ]
+
+    task = asyncio.create_task(router.can_use_tool("AskUserQuestion", {"questions": questions}, ctx))
+
+    # The router should have published a question_request envelope, not the
+    # approval_request shape used for tool gating.
+    raw = await asyncio.wait_for(outbound.get(), timeout=1.0)
+    env = json.loads(raw)
+    assert env["event"] == "question_request"
+    assert env["id"] == "q_1"
+    assert env["questions"] == questions
+
+    # Simulate the dashboard returning the user's pick.
+    router.resolve_question("q_1", {"Which DB?": "Postgres"})
+
+    result = await asyncio.wait_for(task, timeout=1.0)
+    from claude_agent_sdk.types import PermissionResultAllow
+
+    assert isinstance(result, PermissionResultAllow)
+    # The SDK contract requires `updated_input` to carry both the original
+    # questions array and the answers map so claude can synthesise the
+    # tool result correctly.
+    assert result.updated_input == {"questions": questions, "answers": {"Which DB?": "Postgres"}}
+
+
+def test_ask_user_question_with_empty_questions_short_circuits():
+    asyncio.run(_ask_user_question_empty())
+
+
+async def _ask_user_question_empty():
+    outbound: asyncio.Queue = asyncio.Queue()
+    router = approval_router.ApprovalRouter(publish=_queue_publish(outbound))
+    ctx = SimpleNamespace(tool_use_id="q_e")
+
+    result = await router.can_use_tool("AskUserQuestion", {"questions": []}, ctx)
+    from claude_agent_sdk.types import PermissionResultAllow
+
+    assert isinstance(result, PermissionResultAllow)
+    assert result.updated_input["answers"] == {}
+    # No outbound message — nothing to ask.
+    assert outbound.empty()
+
+
+# --- Stream-keep-open hook ------------------------------------------------------
+
+
+def test_keep_stream_open_hook_returns_continue():
+    """The PreToolUse no-op hook is required so the SDK keeps the input
+    channel open long enough for can_use_tool to fire — documented in
+    the Agent SDK 'Handle approvals and user input' page."""
+    result = asyncio.run(sdk_config.keep_stream_open_hook({}, "tu_1", None))
+    assert result == {"continue_": True}
+
+
+# --- Run-id scanning -----------------------------------------------------------
+
+
+def test_scan_for_run_ids_picks_id_out_of_tool_result_text():
+    from claude_agent_sdk.types import ToolResultBlock, UserMessage
+
+    rw = MagicMock()
+    msg = UserMessage(
+        content=[
+            ToolResultBlock(
+                tool_use_id="tu_1", content="Run ID: a14ca1c1-56a7-4ae6-b054-51741adfbee5\nRun Name: foo", is_error=False
+            )
+        ],
+        parent_tool_use_id=None,
+        tool_use_result=None,
+        uuid=None,
+    )
+    bridge.scan_for_run_ids(msg, rw)
+    rw.watch.assert_called_with("a14ca1c1-56a7-4ae6-b054-51741adfbee5")
+
+
+def test_scan_for_run_ids_ignores_non_user_messages():
+    from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+    rw = MagicMock()
+    msg = AssistantMessage(
+        content=[TextBlock(text="Run ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")],
+        model="m",
+        parent_tool_use_id=None,
+        error=None,
+        usage=None,
+        message_id=None,
+        stop_reason=None,
+        session_id=None,
+        uuid=None,
+    )
+    bridge.scan_for_run_ids(msg, rw)
+    rw.watch.assert_not_called()
+
+
+# --- peek_model ----------------------------------------------------------------
+
+
+def test_peek_model_reads_space_separated_form():
+    assert sdk_config.peek_model(["--model", "opus", "--debug"]) == "opus"
+
+
+def test_peek_model_reads_equals_form():
+    assert sdk_config.peek_model(["--model=sonnet"]) == "sonnet"
+
+
+def test_peek_model_returns_none_when_absent():
+    assert sdk_config.peek_model(["--debug", "--add-dir", "/tmp"]) is None
+
+
+# --- summarise -----------------------------------------------------------------
+
+
+def test_summarise_prefers_command_then_truncates():
+    assert envelopes.summarise("Bash", {"command": "ls -la"}) == "ls -la"
+    long = "x" * 500
+    out = envelopes.summarise("Bash", {"command": long})
+    assert out.endswith("…") and len(out) == 198  # 197 chars + ellipsis
+
+
+def test_summarise_non_dict_input_returns_tool_name():
+    assert envelopes.summarise("Bash", None) == "Bash"
+
+
+# --- render_ui_context_preamble ------------------------------------------------
+
+
+def test_render_ui_context_preamble_empty_when_no_context():
+    assert envelopes.render_ui_context_preamble(None) == ""
+    assert envelopes.render_ui_context_preamble({}) == ""
+
+
+def test_render_ui_context_preamble_wraps_fields_in_system_reminder():
+    out = envelopes.render_ui_context_preamble({"run_id": "r1", "step": 3, "best_metric": 7.5})
+    assert out.startswith("<system-reminder>")
+    assert out.rstrip().endswith("</system-reminder>")
+    assert "Run ID: r1" in out
+    assert "Active step: 3" in out
+    assert "Best metric: 7.5" in out
+
+
+# --- Approval card mount-failure fallback --------------------------------------
+
+
+def test_on_approval_request_denies_once_when_card_mount_fails():
+    """If mounting the inline card raises, the SDK approval must still
+    resolve (deny-once) instead of hanging forever on an unmounted card."""
+    pytest.importorskip("textual")
+    asyncio.run(_on_approval_request_denies_on_mount_failure())
+
+
+async def _on_approval_request_denies_on_mount_failure():
+    from weco.commands.start.tui_bridge import Orchestrator
+    from weco.commands.start.session import DashboardSession
+
+    class BrokenApp:
+        def mount_inline_card(self, card):
+            raise RuntimeError("no terminal")
+
+    orch = Orchestrator(
+        app=BrokenApp(),
+        claude_args=[],
+        api_key="weco-k",
+        session=DashboardSession.offline(),
+        billing="weco",
+        weco_api_base=None,
+        effort=None,
+    )
+    router = approval_router.ApprovalRouter(publish=orch._session.publish)
+    orch._approval_router = router
+
+    # Stand in for the SDK's awaited approval future.
+    sdk_future = asyncio.get_running_loop().create_future()
+    router._pending_approvals["rid"] = sdk_future
+
+    orch._on_approval_request("rid", "Bash", "ls", {"command": "ls"})
+    decided = await asyncio.wait_for(sdk_future, timeout=1.0)
+    assert decided == {"decision": "deny", "scope": "once"}
+
+
+# --- Turn-stream drain (off-by-one recovery) -----------------------------------
+
+
+def _fake_result_message():
+    from claude_agent_sdk.types import ResultMessage
+
+    return ResultMessage(
+        subtype="success",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=False,
+        num_turns=1,
+        session_id="s",
+        stop_reason="end_turn",
+        total_cost_usd=0.0,
+        usage={},
+        result="",
+        structured_output=None,
+        model_usage=None,
+        permission_denials=None,
+        deferred_tool_use=None,
+        errors=None,
+        api_error_status=None,
+        uuid=None,
+    )
+
+
+def _fake_orchestrator(**overrides):
+    """Minimal Orchestrator stand-in for exercising `_fan_out`/`_consume_messages`
+    in isolation. Returns (fake, published, rendered)."""
+    published: list = []
+    rendered: list = []
+    fields = {
+        "_session": SimpleNamespace(publish=published.append),
+        "_renderer": SimpleNamespace(render=rendered.append),
+        "_run_watcher": None,
+        "_interrupting": False,
+        "_inflight_turns": 0,
+        **overrides,
+    }
+    return SimpleNamespace(**fields), published, rendered
+
+
+def test_consume_keeps_draining_past_result_message():
+    # A ResultMessage ends a turn, but the continuous consumer must keep going —
+    # a message produced after it (an autonomous/between-turn one) must surface
+    # immediately, not wait for the next prompt. This is the bug the rewrite
+    # fixes: the old per-turn receive_response() stopped at ResultMessage, so
+    # between-turn output stranded in the transport until the next query().
+    seen = []
+    rmsg = _fake_result_message()
+    after = SimpleNamespace(type="autonomous-after")
+    items = [SimpleNamespace(type="reply"), rmsg, after]
+
+    class FakeClient:
+        def receive_messages(self):
+            async def gen():
+                for it in items:
+                    yield it
+
+            return gen()
+
+    fake = SimpleNamespace(_sdk_client=FakeClient(), _stop_event=asyncio.Event(), _fan_out=seen.append)
+    asyncio.run(bridge.Orchestrator._consume_messages(fake))
+    assert seen == items  # every message fanned out, including the one after the ResultMessage
+    assert fake._stop_event.is_set()  # stream end brings the session down so the pump unblocks
+
+
+def test_fan_out_mirrors_and_renders_result():
+    fake, published, rendered = _fake_orchestrator(_inflight_turns=1)
+    rmsg = _fake_result_message()
+    bridge.Orchestrator._fan_out(fake, rmsg)
+    assert fake._inflight_turns == 0  # turn settled
+    assert rendered == [rmsg]  # shown locally
+    assert len(published) == 1  # mirrored to dashboard
+
+
+def test_fan_out_swallows_interrupted_result_and_clears_flag():
+    fake, published, rendered = _fake_orchestrator(_inflight_turns=1, _interrupting=True)
+    bridge.Orchestrator._fan_out(fake, _fake_result_message())
+    assert fake._inflight_turns == 0  # still settles the count
+    assert fake._interrupting is False  # cleared on the interrupted turn's terminal message
+    assert published == []  # not mirrored — turn_interrupted already signalled the end
+    assert rendered == []  # not rendered as an error bubble

--- a/tests/test_start_cli.py
+++ b/tests/test_start_cli.py
@@ -1,0 +1,20 @@
+"""Tests for `weco start claude` pre-flight checks."""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+from weco.commands.start import cli
+
+
+def test_require_claude_cli_exits_when_not_installed(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
+    with pytest.raises(SystemExit) as exc:
+        cli._require_claude_cli(Console())
+    assert exc.value.code == 1
+
+
+def test_require_claude_cli_passes_when_installed(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: "/usr/local/bin/claude")
+    cli._require_claude_cli(Console())  # no exit

--- a/tests/test_start_relay.py
+++ b/tests/test_start_relay.py
@@ -1,0 +1,45 @@
+"""Tests for the low-level Realtime channel pump (`relay`).
+
+Live Realtime connection / JWT refresh / channel subscription is exercised
+end-to-end against a real Supabase instance, not here. These cover the
+local-only seams: UTF-8-safe chunking and timestamp parsing. Session REST
+now lives on ``WecoClient`` / ``DashboardSession`` (see ``test_start_session``).
+"""
+
+from __future__ import annotations
+
+from weco.commands.start import relay
+
+
+# --- _chunk_utf8 ---------------------------------------------------------------
+
+
+def test_chunk_short_strings_pass_through_unchanged():
+    chunks = list(relay._chunk_utf8("hello", 100))
+    assert chunks == ["hello"]
+
+
+def test_chunk_splits_long_ascii_at_byte_limit():
+    s = "a" * 1000
+    chunks = list(relay._chunk_utf8(s, 256))
+    assert "".join(chunks) == s
+    assert all(len(c.encode("utf-8")) <= 256 for c in chunks)
+    assert len(chunks) == 4  # 1000 / 256 rounded up
+
+
+def test_chunk_does_not_split_multibyte_chars():
+    # 4-byte char repeated; naive byte slicing would corrupt mid-char.
+    s = "𠮷" * 200  # each char is 4 bytes in UTF-8
+    chunks = list(relay._chunk_utf8(s, 17))  # awkward boundary
+    assert "".join(chunks) == s
+    for c in chunks:
+        c.encode("utf-8").decode("utf-8")
+
+
+# --- _parse_iso ----------------------------------------------------------------
+
+
+def test_parse_iso_handles_z_suffix():
+    ts = relay._parse_iso("2026-05-05T12:00:00Z")
+    # Just sanity: it's a unix timestamp around the right magnitude.
+    assert ts > 1_700_000_000

--- a/tests/test_start_run_watcher.py
+++ b/tests/test_start_run_watcher.py
@@ -1,0 +1,349 @@
+"""Tests for the wrapper-side weco-run watcher."""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+from weco.commands.start.run_watcher import (
+    RunWatcher,
+    build_idle_heartbeat_message,
+    build_new_best_message,
+    build_pending_review_message,
+    build_status_change_message,
+    build_step_advance_message,
+    find_run_ids,
+)
+
+
+# --- find_run_ids ---
+
+
+def test_find_run_ids_picks_canonical_format():
+    text = "Run ID: a14ca1c1-56a7-4ae6-b054-51741adfbee5\nRun Name: hello\n"
+    assert find_run_ids(text) == ["a14ca1c1-56a7-4ae6-b054-51741adfbee5"]
+
+
+def test_find_run_ids_dedupes_and_preserves_order():
+    text = (
+        "Run ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n"
+        "Run ID: 11111111-2222-3333-4444-555555555555\n"
+        "Run ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n"
+    )
+    assert find_run_ids(text) == ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "11111111-2222-3333-4444-555555555555"]
+
+
+def test_find_run_ids_returns_empty_when_absent():
+    assert find_run_ids("just a normal line\nno ids here") == []
+
+
+def test_find_run_ids_only_matches_anchored_lines():
+    """The marker has to start the line — random "Run ID:" mentions in prose
+    shouldn't trigger a false start of polling."""
+    text = "I'm thinking about: Run ID: aaaa-..."
+    assert find_run_ids(text) == []
+
+
+def test_find_run_ids_extracts_from_stream_json_tool_result():
+    """The bridge feeds us claude's stream-json line. The run-id line is buried
+    in a JSON-escaped string with `\\n` literals — we should still find it."""
+    rid = "a14ca1c1-56a7-4ae6-b054-51741adfbee5"
+    event = {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": (f"WECO OPTIMIZATION RUN\n============================\nRun ID: {rid}\nRun Name: hello\n"),
+                }
+            ],
+        },
+    }
+    assert find_run_ids(json.dumps(event)) == [rid]
+
+
+# --- build_status_change_message ---
+
+
+def test_build_status_change_message_for_completion_includes_results_hint():
+    msg = build_status_change_message(
+        "rid-1",
+        {"status": "completed", "best_metric": 3.21, "best_step": 7, "current_step": 15, "total_steps": 15},
+        prev="running",
+    )
+    assert msg is not None
+    assert msg["kind"] == "completed"
+    assert msg["level"] == "success"
+    assert "completed" in msg["text"]
+    assert "3.21" in msg["text"]
+    assert any("weco run results rid-1" in h for h in msg["hints"])
+
+
+def test_build_status_change_message_for_error_marks_error_level():
+    msg = build_status_change_message("rid-2", {"status": "error", "current_step": 3, "total_steps": 15}, prev="running")
+    assert msg is not None
+    assert msg["kind"] == "errored"
+    assert msg["level"] == "error"
+    assert "errored" in msg["text"]
+
+
+def test_build_status_change_message_skips_first_observation_when_idle():
+    """A run we just started watching that's already in 'running' but step 0
+    isn't worth a message — it's just initial pickup."""
+    out = build_status_change_message("r", {"status": "running", "current_step": 0, "total_steps": 15}, prev=None)
+    assert out is None
+
+
+def test_build_status_change_message_skips_first_observation_even_mid_run():
+    """`_poll` already emits an immediate `attached` event for run pickup, so
+    a first observation of a running run — even one already past step 0 —
+    must not produce a duplicate announcement here."""
+    out = build_status_change_message("r", {"status": "running", "current_step": 8, "total_steps": 15}, prev=None)
+    assert out is None
+
+
+def test_build_status_change_message_returns_none_when_status_missing():
+    assert build_status_change_message("r", {}, prev=None) is None
+
+
+def test_build_status_change_message_handles_stopped_status():
+    msg = build_status_change_message("r", {"status": "stopped"}, prev="running")
+    assert msg is not None
+    assert msg["kind"] == "stopped"
+    assert msg["level"] == "warning"
+    assert "stopped" in msg["text"].lower()
+
+
+def test_update_carries_lineage_root_id_when_present():
+    # Derived sub-runs poll under their own run_id but the dashboard navigates
+    # by lineage root, so the root id must ride along on the update.
+    status = {"status": "running", "current_step": 3, "total_steps": 5, "lineage_id": "root-1"}
+    advance = build_step_advance_message("derived-9", status)
+    assert advance is not None
+    assert advance["run_id"] == "derived-9"
+    assert advance["lineage_id"] == "root-1"
+    errored = build_status_change_message("derived-9", {"status": "error", "lineage_id": "root-1"}, prev="running")
+    assert errored is not None
+    assert errored["lineage_id"] == "root-1"
+
+
+def test_update_lineage_id_is_none_for_non_derived_runs():
+    # No lineage info in status (plain run) → lineage_id is None; the dashboard
+    # falls back to run_id.
+    msg = build_step_advance_message("r", {"current_step": 1, "total_steps": 5})
+    assert msg is not None
+    assert msg["lineage_id"] is None
+
+
+# --- build_new_best_message ---
+
+
+def test_build_new_best_message_includes_metric_and_step():
+    msg = build_new_best_message("r-abc", {"best_metric": 3.14, "best_step": 4, "current_step": 5, "total_steps": 15})
+    assert msg is not None
+    assert msg["kind"] == "new_best"
+    assert msg["level"] == "success"
+    assert "3.14" in msg["text"]
+    assert "step 4" in msg["text"]
+    assert "5/15" in msg["text"]
+
+
+def test_build_new_best_message_returns_none_when_no_metric():
+    assert build_new_best_message("r", {}) is None
+    assert build_new_best_message("r", {"best_metric": 1.5}) is None  # missing best_step
+
+
+# --- build_step_advance_message ---
+
+
+def test_build_step_advance_message_includes_progress_and_best():
+    msg = build_step_advance_message("r-x", {"current_step": 4, "total_steps": 12, "best_metric": 1.7, "best_step": 2})
+    assert msg is not None
+    assert msg["kind"] == "step_advance"
+    assert "step 4/12" in msg["text"]
+    assert "1.7" in msg["text"]
+
+
+def test_build_step_advance_message_returns_none_without_step():
+    assert build_step_advance_message("r", {}) is None
+
+
+# --- build_pending_review_message ---
+
+
+def test_build_pending_review_message_mentions_count_and_command():
+    msg = build_pending_review_message("r-pr", {"pending_nodes": [{"node_id": "a"}, {"node_id": "b"}]})
+    assert msg is not None
+    assert msg["kind"] == "pending_review"
+    assert "2 nodes" in msg["text"]
+    assert any("weco run review r-pr" in h for h in msg["hints"])
+
+
+def test_build_pending_review_message_returns_none_when_empty():
+    assert build_pending_review_message("r", {}) is None
+    assert build_pending_review_message("r", {"pending_nodes": []}) is None
+
+
+# --- build_idle_heartbeat_message ---
+
+
+def test_build_idle_heartbeat_message_includes_idle_minutes_and_progress():
+    msg = build_idle_heartbeat_message(
+        "r-idle", {"current_step": 3, "total_steps": 10, "best_metric": 1.5, "best_step": 1}, idle_seconds=125.0
+    )
+    assert msg is not None
+    assert msg["kind"] == "idle"
+    assert "step 3/10" in msg["text"]
+    assert "best 1.5 at step 1" in msg["text"]
+    assert "~2 minutes" in msg["text"]
+
+
+def test_build_idle_heartbeat_message_uses_singular_minute_for_short_idle():
+    msg = build_idle_heartbeat_message("r", {"current_step": 0}, idle_seconds=45.0)
+    assert msg is not None
+    assert "~1 minute" in msg["text"]
+    assert "minutes" not in msg["text"]
+
+
+# --- RunWatcher integration with mocked subprocess ---
+
+
+def _collect_via_watcher(statuses: list[dict]) -> list[dict]:
+    """Drive the watcher with a canned status sequence; return all updates emitted."""
+    iterator = iter(statuses)
+
+    async def fake_fetch(_self, run_id):
+        try:
+            return next(iterator)
+        except StopIteration:
+            return None
+
+    received: list[dict] = []
+
+    def notify(update: dict) -> None:
+        received.append(update)
+
+    async def body():
+        stop_event = asyncio.Event()
+        watcher = RunWatcher(weco_bin="/usr/bin/true", notify=notify, stop_event=stop_event, poll_interval_s=0.01)
+        with patch.object(RunWatcher, "_fetch_status", fake_fetch):
+            assert watcher.watch("r1") is True
+            for _ in range(200):
+                if not watcher.watching():
+                    break
+                await asyncio.sleep(0.02)
+            await watcher.stop()
+
+    asyncio.run(body())
+    return received
+
+
+def test_watcher_starts_polling_and_announces_completion():
+    out = _collect_via_watcher(
+        [
+            {"status": "running", "current_step": 1, "total_steps": 5},
+            {"status": "running", "current_step": 3, "total_steps": 5},
+            {"status": "completed", "best_metric": 2.4, "best_step": 4, "current_step": 5, "total_steps": 5},
+        ]
+    )
+    assert any(u["kind"] == "completed" for u in out)
+
+
+def test_watcher_announces_on_new_best_metric_within_running():
+    out = _collect_via_watcher(
+        [
+            {"status": "running", "current_step": 0, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+            {"status": "running", "current_step": 1, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+            {"status": "running", "current_step": 2, "total_steps": 5, "best_step": 2, "best_metric": 2.5},
+            {"status": "completed", "current_step": 5, "total_steps": 5, "best_step": 2, "best_metric": 2.5},
+        ]
+    )
+    assert any(u["kind"] == "new_best" for u in out)
+    assert any(u["kind"] == "completed" for u in out)
+
+
+def test_watcher_announces_step_transitions_without_improvement():
+    out = _collect_via_watcher(
+        [
+            {"status": "running", "current_step": 0, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+            {"status": "running", "current_step": 1, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+            {"status": "running", "current_step": 2, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+            {"status": "running", "current_step": 3, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+            {"status": "completed", "current_step": 5, "total_steps": 5, "best_step": 0, "best_metric": 1.0},
+        ]
+    )
+    assert sum(1 for u in out if u["kind"] == "new_best") == 0
+    assert sum(1 for u in out if u["kind"] == "step_advance") >= 1
+    assert any(u["kind"] == "completed" for u in out)
+
+
+def test_watcher_announces_when_pending_review_grows():
+    out = _collect_via_watcher(
+        [
+            {
+                "status": "running",
+                "current_step": 1,
+                "total_steps": 5,
+                "best_step": 0,
+                "best_metric": 1.0,
+                "pending_nodes": [],
+            },
+            {
+                "status": "running",
+                "current_step": 1,
+                "total_steps": 5,
+                "best_step": 0,
+                "best_metric": 1.0,
+                "pending_nodes": [{"node_id": "a"}, {"node_id": "b"}],
+            },
+            {
+                "status": "completed",
+                "current_step": 5,
+                "total_steps": 5,
+                "best_step": 0,
+                "best_metric": 1.0,
+                "pending_nodes": [],
+            },
+        ]
+    )
+    assert any(u["kind"] == "pending_review" for u in out)
+
+
+def test_watcher_dedupes_concurrent_watches():
+    """Calling watch() twice for the same id is a no-op the second time."""
+
+    async def body():
+        stop_event = asyncio.Event()
+        watcher = RunWatcher(weco_bin="/usr/bin/true", notify=lambda _u: None, stop_event=stop_event, poll_interval_s=10.0)
+        first = watcher.watch("r-dup")
+        second = watcher.watch("r-dup")
+        await watcher.stop()
+        return first, second
+
+    first, second = asyncio.run(body())
+    assert first is True
+    assert second is False
+
+
+def test_watcher_no_op_without_weco_bin():
+    """If `weco` isn't on PATH, the watcher silently does nothing."""
+
+    async def body() -> bool:
+        stop_event = asyncio.Event()
+        watcher = RunWatcher(weco_bin=None, notify=lambda _u: None, stop_event=stop_event)
+        return watcher.watch("r")
+
+    assert asyncio.run(body()) is False
+
+
+def test_watcher_stop_idempotent():
+    """Calling stop() multiple times is safe."""
+
+    async def body():
+        stop_event = asyncio.Event()
+        watcher = RunWatcher(weco_bin="/usr/bin/true", notify=lambda _u: None, stop_event=stop_event, poll_interval_s=10.0)
+        watcher.watch("r")
+        await watcher.stop()
+        await watcher.stop()
+
+    asyncio.run(body())

--- a/tests/test_start_session.py
+++ b/tests/test_start_session.py
@@ -1,0 +1,102 @@
+"""Tests for DashboardSession + the WecoClient session-REST methods.
+
+Real Realtime/channel behaviour is exercised end-to-end elsewhere; here we
+cover the local seams: the offline no-op session, the create handshake, and
+error translation to SetupError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from weco.commands.start.session import DashboardSession, SetupError
+
+
+FAKE_SESSION = {
+    "session": {"id": "sess-1"},
+    "dashboard_url": "https://dashboard.weco.ai/sessions/sess-1",
+    "realtime": {"url": "wss://x", "token": "t", "expires_at": "2026-05-05T13:00:00+00:00", "channel": "agent:sess-1"},
+}
+
+
+# --- offline -------------------------------------------------------------------
+
+
+def test_offline_session_is_inert():
+    asyncio.run(_offline_session_is_inert())
+
+
+async def _offline_session_is_inert():
+    s = DashboardSession.offline()
+    assert s.online is False
+    assert s.id is None
+    assert s.dashboard_url is None
+    # publish still accepts into the (undrained) queue, matching legacy behaviour.
+    assert s.publish("a line") is True
+    # run() returns immediately rather than trying to open a channel.
+    await asyncio.wait_for(s.run(on_inbound=lambda _m: None, stop_event=asyncio.Event()), timeout=1.0)
+
+
+# --- create --------------------------------------------------------------------
+
+
+def test_create_exposes_id_and_url_and_marks_online():
+    with patch("weco.commands.start.session.WecoClient") as MockClient:
+        MockClient.return_value.create_session.return_value = FAKE_SESSION
+        s = DashboardSession.create(api_key="weco-k", agent_type="claude-code")
+    assert s.online is True
+    assert s.id == "sess-1"
+    assert s.dashboard_url == "https://dashboard.weco.ai/sessions/sess-1"
+    # Built with a bearer header derived from the api key.
+    assert MockClient.call_args.args[0] == {"Authorization": "Bearer weco-k"}
+    MockClient.return_value.create_session.assert_called_once_with("claude-code")
+
+
+def test_create_translates_http_error_to_setup_error():
+    resp = MagicMock(status_code=402, text="insufficient credits")
+    err = requests.HTTPError(response=resp)
+    with patch("weco.commands.start.session.WecoClient") as MockClient:
+        MockClient.return_value.create_session.side_effect = err
+        with pytest.raises(SetupError) as excinfo:
+            DashboardSession.create(api_key="weco-k", agent_type="claude-code")
+    assert "402" in str(excinfo.value)
+
+
+def test_create_translates_network_error_to_setup_error():
+    with patch("weco.commands.start.session.WecoClient") as MockClient:
+        MockClient.return_value.create_session.side_effect = requests.ConnectionError("no route")
+        with pytest.raises(SetupError):
+            DashboardSession.create(api_key="weco-k", agent_type="claude-code")
+
+
+# --- WecoClient session REST ---------------------------------------------------
+
+
+def test_weco_client_create_session_posts_agent_type():
+    from weco.core.api import WecoClient
+
+    client = WecoClient({"Authorization": "Bearer weco-k"})
+    fake = MagicMock(status_code=200)
+    fake.json.return_value = FAKE_SESSION
+    fake.raise_for_status.return_value = None
+    with patch.object(client._session, "post", return_value=fake) as post:
+        out = client.create_session("claude-code")
+    assert out == FAKE_SESSION
+    url = post.call_args.args[0]
+    assert url.endswith("/sessions")
+    assert post.call_args.kwargs["json"] == {"agent_type": "claude-code"}
+
+
+def test_weco_client_close_session_patches_status():
+    from weco.core.api import WecoClient
+
+    client = WecoClient({"Authorization": "Bearer weco-k"})
+    with patch.object(client._session, "patch", return_value=MagicMock(status_code=200)) as patch_call:
+        client.close_session("sess-1")
+    url = patch_call.call_args.args[0]
+    assert url.endswith("/sessions/sess-1")
+    assert patch_call.call_args.kwargs["json"] == {"status": "closed"}

--- a/tests/test_ui_tui_app.py
+++ b/tests/test_ui_tui_app.py
@@ -1,0 +1,77 @@
+"""Smoke tests for the Textual TUI app (no real `claude` subprocess).
+
+We drive WecoTUI via its public ``post_*`` surface and assert that the
+expected widgets land in the message log. Uses Textual's headless test
+harness so no real terminal is required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("textual")
+
+from weco.ui.tui import WecoTUI
+from weco.ui.tui.widgets import AssistantMessage, RunUpdate, SystemNotice, ToolCallCard, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_app_renders_full_turn_sequence():
+    """Drive a representative event sequence; verify each kind of widget mounts."""
+    app = WecoTUI()
+    async with app.run_test() as pilot:
+        app.post_system_notice("— claude ready —")
+        app.post_user_message("read the file and update the greeting")
+        app.post_assistant_delta("I'll take a look ")
+        app.post_assistant_delta("and update it.\n")
+        app.post_tool_use("t1", "Read", "/tmp/example.py", {"file_path": "/tmp/example.py"})
+        app.post_tool_result("t1", "def greet(name):\n    return f'hi {name}'\n", is_error=False)
+        app.post_tool_use(
+            "t2",
+            "Edit",
+            "/tmp/example.py",
+            {
+                "file_path": "/tmp/example.py",
+                "old_string": "    return f'hi {name}'",
+                "new_string": "    return f'hello, {name}!'",
+            },
+        )
+        app.post_tool_result("t2", "ok", is_error=False)
+        app.post_run_update(
+            {
+                "kind": "new_best",
+                "run_id": "abc12345-aaaa-bbbb-cccc-ddddeeeeffff",
+                "text": "new best metric: 0.92",
+                "hints": ["view: weco run show <id>"],
+            }
+        )
+        app.post_turn_end("success", cost=0.0123, duration_ms=4210)
+
+        # Yield to the event loop so mounts settle.
+        await pilot.pause()
+
+        app.query(".message")  # no class filter — count by type instead
+        assert app.query(UserMessage)
+        assert app.query(AssistantMessage)
+        assert len(app.query(ToolCallCard)) == 2
+        assert app.query(RunUpdate)
+        # We expect at least: claude-ready + turn-end notices.
+        assert len(app.query(SystemNotice)) >= 2
+
+
+@pytest.mark.asyncio
+async def test_user_input_invokes_submit_callback():
+    """Pressing Enter in the input should call the bridge's submit callback."""
+    received: list[str] = []
+
+    async def cb(text: str) -> None:
+        received.append(text)
+
+    app = WecoTUI(submit_callback=cb)
+    async with app.run_test() as pilot:
+        app.query_one("#prompt").value = "hello"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert received == ["hello"]
+        # The app should also have echoed the prompt as a UserMessage.
+        assert app.query(UserMessage)

--- a/tests/test_ui_tui_approval.py
+++ b/tests/test_ui_tui_approval.py
@@ -1,0 +1,90 @@
+"""Tests for the inline tool-call approval card.
+
+`ApprovalCard` is the AskUserQuestion picker (`QuestionCard`) reused for
+tool gating — these cover the label→decision translation and the
+cross-surface resolve paths the bridge depends on. No Textual app is
+mounted; the card's `_mark_done` query is guarded, so we drive its
+terminal methods directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("textual")
+
+from weco.ui.tui.approval import ApprovalCard
+
+
+def _make_card(tool_name="Bash", summary="rm -rf build/"):
+    future: asyncio.Future = asyncio.get_running_loop().create_future()
+    return ApprovalCard(tool_name, summary, future), future
+
+
+def test_selected_label_maps_to_decision():
+    asyncio.run(_selected_label_maps_to_decision())
+
+
+async def _selected_label_maps_to_decision():
+    for label, expected in (
+        ("Allow once", ("approve", "once")),
+        ("Allow always", ("approve", "always")),
+        ("Deny", ("deny", "once")),
+    ):
+        card, future = _make_card()
+        # The OptionList records the picked label under the question key;
+        # `_submit` is what the picker fires once a single question is done.
+        card._answers = {"Allow Bash?": label}
+        card._submit()
+        assert future.result() == expected
+
+
+def test_summary_rides_as_detail_not_question_text():
+    asyncio.run(_summary_rides_as_detail())
+
+
+async def _summary_rides_as_detail():
+    card, _ = _make_card(tool_name="Bash", summary="rm -rf build/")
+    q = card._questions[0]
+    # Short question text keeps the collapsed "✓ … → answer" line readable;
+    # the arbitrary summary lives on the detail sub-line.
+    assert q["question"] == "Allow Bash?"
+    assert q["detail"] == "rm -rf build/"
+
+
+def test_escape_denies_once():
+    asyncio.run(_escape_denies_once())
+
+
+async def _escape_denies_once():
+    card, future = _make_card()
+    card._cancel()
+    assert future.result() == ("deny", "once")
+
+
+def test_dashboard_answer_freezes_card_with_its_decision():
+    asyncio.run(_dashboard_answer_freezes_card())
+
+
+async def _dashboard_answer_freezes_card():
+    card, future = _make_card()
+    card.resolve_remotely_decision("approve", "command")
+    assert future.result() == ("approve", "command")
+    # A late local pick can't double-resolve the SDK call.
+    card._answers = {"Allow Bash?": "Deny"}
+    card._submit()
+    assert future.result() == ("approve", "command")
+
+
+def test_turn_cancel_shim_denies_once():
+    asyncio.run(_turn_cancel_shim_denies_once())
+
+
+async def _turn_cancel_shim_denies_once():
+    card, future = _make_card()
+    # The bridge's generic cleanup calls resolve_remotely({}) on every
+    # active card; for an approval that means deny-once.
+    card.resolve_remotely({})
+    assert future.result() == ("deny", "once")

--- a/weco/api.py
+++ b/weco/api.py
@@ -185,6 +185,18 @@ def get_execution_tasks(
     return WecoClient(auth_headers).get_execution_tasks(run_id)
 
 
+def get_lineage_execution_tasks(
+    lineage_id: str, auth_headers: dict = {}, timeout: Union[int, Tuple[int, int]] = (5, 30)
+) -> Optional[ExecutionTasksResult]:
+    """Poll for ready execution tasks across an entire lineage."""
+    return WecoClient(auth_headers).get_lineage_execution_tasks(lineage_id)
+
+
+def send_lineage_heartbeat(lineage_id: str, auth_headers: dict = {}) -> bool:
+    """Heartbeat every running member of a lineage in one call."""
+    return WecoClient(auth_headers).heartbeat_lineage(lineage_id)
+
+
 def claim_execution_task(
     task_id: str, auth_headers: dict = {}, timeout: Union[int, Tuple[int, int]] = (5, 30)
 ) -> Optional[Dict[str, Any]]:

--- a/weco/cli.py
+++ b/weco/cli.py
@@ -176,6 +176,25 @@ Default models for providers:
         default=5,
         help="Max auto-resume attempts before giving up and printing the manual resume command (default: 5).",
     )
+    run_parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help=(
+            "Detach the run after creating it. Prints the run id and exits, leaving the eval loop "
+            "running in the background. Stdout/stderr of the detached process go to "
+            "/tmp/weco-run-<run-id>.log. Pass this when launching from inside `weco start <agent>` so "
+            "the wrapper can attach a watcher and the run survives agent subprocess lifecycle."
+        ),
+    )
+    run_parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help=(
+            "Don't auto-open the run's dashboard URL in a browser tab. Implicit when launched from "
+            "inside `weco start <agent>` (the attached dashboard updates in-place via a session-scoped "
+            "toast instead)."
+        ),
+    )
 
     # --- Eval backend integration ---
     run_parser.add_argument(
@@ -259,6 +278,20 @@ def _configure_run_subcommands(run_parser: argparse.ArgumentParser) -> None:
         choices=["rich", "plain"],
         default="rich",
         help="Output mode: 'rich' for interactive UI, 'plain' for machine-readable output",
+    )
+    p.add_argument(
+        "--daemon",
+        action="store_true",
+        help=(
+            "Detach the derived run after creating it. Prints the run id and exits, leaving the eval "
+            "loop in the background; stdout/stderr go to /tmp/weco-run-<run-id>.log. Pass when "
+            "launching from inside `weco start <agent>` so the wrapper can attach a watcher."
+        ),
+    )
+    p.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Don't auto-open the derived run in a browser tab. Implicit when launched from `weco start`.",
     )
 
     # weco run submit <run-id> --node <id>
@@ -403,6 +436,19 @@ Supported provider names: {supported_providers}.
         default=5,
         help="Max auto-resume attempts before giving up and printing the manual resume command (default: 5).",
     )
+    resume_parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Don't auto-open the run in a browser tab. Implicit when launched from `weco start`.",
+    )
+    resume_parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help=(
+            "Detach the resumed run. Prints the run id and exits, leaving the eval loop in the "
+            "background; stdout/stderr go to /tmp/weco-run-<run-id>.log."
+        ),
+    )
 
 
 def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
@@ -436,6 +482,8 @@ def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
             api_keys=parse_api_keys(args.api_key),
             output_mode=args.output,
             console=console,
+            daemon=getattr(args, "daemon", False),
+            no_open=getattr(args, "no_open", False),
         ),
         "stop": lambda: stop.handle(run_id=args.run_id, console=console),
         "instruct": lambda: instruct.handle(run_id=args.run_id, instructions=args.instructions, console=console),
@@ -559,6 +607,8 @@ def execute_run_command(args: argparse.Namespace) -> None:
         output_mode=args.output,
         submit_timeout=getattr(args, "submit_timeout", None),
         auto_resume_policy=auto_resume_policy,
+        daemon=getattr(args, "daemon", False),
+        no_open=getattr(args, "no_open", False),
     )
 
     exit_code = 0 if success else 1
@@ -587,6 +637,8 @@ def execute_resume_command(args: argparse.Namespace) -> None:
         submit_timeout=getattr(args, "submit_timeout", None),
         auto_resume_policy=auto_resume_policy,
         additional_steps=args.steps,
+        daemon=getattr(args, "daemon", False),
+        no_open=getattr(args, "no_open", False),
     )
 
     sys.exit(0 if success else 1)
@@ -673,6 +725,16 @@ def _main() -> None:
     )
     configure_observe_parser(observe_parser)
 
+    # --- Start Command Parser Setup ---
+    from .commands.start import configure_start_parser
+
+    start_parser = subparsers.add_parser(
+        "start",
+        help="Launch tools bridged to the Weco dashboard (e.g., 'weco start claude')",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    configure_start_parser(start_parser)
+
     args = parser.parse_args()
 
     # Initialize environment
@@ -728,6 +790,11 @@ def _main() -> None:
         sys.exit(0)
     elif args.command == "observe":
         execute_observe_command(args)
+        sys.exit(0)
+    elif args.command == "start":
+        from .commands.start import handle_start_command
+
+        handle_start_command(args, console)
         sys.exit(0)
     else:
         # This case should be hit if 'weco' is run alone and chatbot logic didn't catch it,

--- a/weco/commands/run/derive.py
+++ b/weco/commands/run/derive.py
@@ -1,6 +1,7 @@
 """``weco run derive <run-id>`` — create a derived run from an existing run's step."""
 
 import json
+import os
 import pathlib
 import sys
 
@@ -8,13 +9,11 @@ import requests
 from rich.console import Console
 from rich.prompt import Confirm
 
-from ...api import report_termination
-from ...artifacts import RunArtifacts
 from ...auth import handle_authentication
+from ...browser import open_browser
+from ...consumer_lock import consumer_lock
 from ...core.api import WecoClient, handle_api_error
-from ...heartbeat import heartbeat
-from ...optimizer import OptimizationResult, offer_apply_best_solution, run_optimization_loop
-from ...ui import LiveOptimizationUI, PlainOptimizationUI
+from ...optimizer import _daemonize_to_log, _should_auto_open_browser, run_lineage_loop
 from ...utils import read_additional_instructions, read_from_path
 from ... import __dashboard_url__
 
@@ -118,126 +117,51 @@ def _resolve_originals(inherited_source: dict[str, str]) -> dict[str, str]:
     return originals
 
 
-def _print_resume_hint(console: Console, output_mode: str, run_id: str) -> None:
-    """Tell the user how to resume an interrupted run."""
-    hint = f"To resume this run, use: weco resume {run_id}"
-    if output_mode == "plain":
-        print(f"\n{hint}\n", flush=True)
-    else:
-        console.print(f"\n[cyan]{hint}[/]\n")
-
-
-def _drive_optimization(
+def _attach_or_consume(
     *,
     console: Console,
     auth_headers: dict[str, str],
     run_info: dict,
-    artifacts: RunArtifacts,
+    lineage_id: str,
     originals: dict[str, str],
-    dashboard_url: str,
-    output_mode: str,
-    api_keys: dict[str, str] | None,
-) -> OptimizationResult:
-    """Run the optimization loop within heartbeat + UI contexts.
-
-    Always returns an :class:`OptimizationResult` — the loop catches its own
-    exceptions and reports failure rather than raising. Termination is
-    reported to the backend on the way out.
-    """
-    new_run_id = run_info["id"]
-    ui_kwargs = dict(
-        run_id=new_run_id,
-        run_name=run_info["name"],
-        total_steps=run_info["steps"],
-        dashboard_url=dashboard_url,
-        model=run_info["model"],
-        metric_name=run_info["metric_name"],
-        maximize=run_info["maximize"],
-    )
-    if output_mode == "plain":
-        ui_instance = PlainOptimizationUI(**ui_kwargs)
-    else:
-        ui_instance = LiveOptimizationUI(console, **ui_kwargs)
-
-    result: OptimizationResult | None = None
-    try:
-        with heartbeat(new_run_id, auth_headers), ui_instance as ui:
-            # The UI's standard run header (printed by on_init) is the single
-            # source of truth for "what run we just created". The parent
-            # reference is surfaced via the derived_from payload.
-            ui.on_init(derived_from=run_info["derived_from"])
-
-            # The backend has already created the inherited step-0 baseline
-            # and generated the step-1 candidate; the loop picks up step 1.
-            result = run_optimization_loop(
-                ui=ui,
-                run_id=new_run_id,
-                auth_headers=auth_headers,
-                source_code=originals,
-                eval_command=run_info["evaluation_command"],
-                eval_timeout=run_info["eval_timeout"],
-                artifacts=artifacts,
-                save_logs=run_info["save_logs"],
-                start_step=1,
-                api_keys=api_keys,
-            )
-        return result
-    finally:
-        if result is not None:
-            try:
-                report_termination(
-                    run_id=new_run_id,
-                    status_update=result.status,
-                    reason=result.reason,
-                    details=result.details,
-                    auth_headers=auth_headers,
-                )
-            except Exception:
-                pass
-
-
-def _run_derived_loop(
-    *,
-    console: Console,
-    auth_headers: dict[str, str],
-    run_info: dict,
-    originals: dict[str, str],
-    dashboard_url: str,
     output_mode: str,
     api_keys: dict[str, str] | None,
 ) -> bool:
-    """Drive the optimization loop and react to its outcome.
+    """Feed the new derived run to the single lineage consumer.
 
-    Returns ``True`` iff the loop completed successfully.
+    Deriving never spawns its own optimization loop — that's what caused
+    parallel derived runs to evaluate concurrently in one working tree and
+    clobber each other. Instead we try to acquire the working-tree consumer
+    lock:
+
+    * lock **held** — a consumer is already draining this lineage in this tree;
+      it will pick up the new run on its next poll. Print the run id and return.
+    * lock **free** — become the lineage consumer and drain the lineage (this
+      run plus any other active members), one eval at a time.
     """
     new_run_id = run_info["id"]
-    artifacts = RunArtifacts(log_dir=run_info["log_dir"], run_id=new_run_id)
 
-    result = _drive_optimization(
-        console=console,
-        auth_headers=auth_headers,
-        run_info=run_info,
-        artifacts=artifacts,
-        originals=originals,
-        dashboard_url=dashboard_url,
-        output_mode=output_mode,
-        api_keys=api_keys,
-    )
+    with consumer_lock() as acquired:
+        if not acquired:
+            if output_mode == "plain":
+                print(json.dumps({"run_id": new_run_id, "lineage_id": lineage_id, "attached": True}), flush=True)
+            else:
+                console.print(
+                    f"[green]Derived run {new_run_id} created.[/] An active consumer in this directory will evaluate it."
+                )
+            return True
 
-    if result.status == "terminated":
-        _print_resume_hint(console, output_mode, new_run_id)
-
-    if result.success:
-        offer_apply_best_solution(
-            console=console,
-            run_id=new_run_id,
-            source_code=originals,
-            artifacts=artifacts,
+        return run_lineage_loop(
+            lineage_id=lineage_id,
             auth_headers=auth_headers,
-            apply_change=False,
+            originals=originals,
+            eval_command=run_info["evaluation_command"],
+            eval_timeout=run_info["eval_timeout"],
+            save_logs=run_info["save_logs"],
+            log_dir=run_info["log_dir"],
+            dashboard_base=__dashboard_url__,
+            api_keys=api_keys,
         )
-
-    return result.success
 
 
 # ---------------------------------------------------------------------------
@@ -253,12 +177,15 @@ def handle(
     api_keys: dict[str, str] | None,
     output_mode: str,
     console: Console,
+    daemon: bool = False,
+    no_open: bool = False,
 ) -> bool:
-    """Create a derived run and run the local optimization loop against it.
+    """Create a derived run and feed it to the single lineage consumer.
 
-    Returns ``True`` on successful completion, ``False`` if the loop failed,
-    was terminated, or errored out. The dispatcher uses this to set the
-    process exit code.
+    Never spawns its own optimization loop — if a consumer is already draining
+    this lineage in the working tree, the new run is picked up by it; otherwise
+    this process becomes that consumer. Returns ``True`` on success, ``False``
+    on failure. The dispatcher uses this to set the process exit code.
     """
     weco_api_key, auth_headers = handle_authentication(console)
     if weco_api_key is None:
@@ -290,24 +217,62 @@ def handle(
 
     run_info = response["run"]
     new_run_id = run_info["id"]
-    dashboard_url = f"{__dashboard_url__}/runs/{new_run_id}"
+    # A derived run is never its own dashboard page — it lives inside its
+    # root run's lineage tree. Point the dashboard link at the lineage root
+    # (the derived run's `lineage_id`) so we don't open a dead-end tab for
+    # the sub-run; it surfaces under the root instead. Falls back to the
+    # run's own id for the (non-derived) safety case where lineage_id is
+    # absent.
+    lineage_id = run_info.get("lineage_id") or new_run_id
+    dashboard_url = f"{__dashboard_url__}/runs/{lineage_id}"
 
     originals = _resolve_originals(run_info["source_code"])
 
-    if output_mode != "plain" and not Confirm.ask(
-        "Have the source files in your working directory been kept consistent with "
-        "the parent run? Local edits will override the inherited baseline.",
-        default=True,
+    # Skip the interactive confirm when there's no human at the terminal:
+    #   * daemon mode — we've forked, no stdin;
+    #   * plain output — non-interactive caller;
+    #   * agent session — the derive was driven by the agent in `weco start`
+    #     (signalled by WECO_CC_SESSION_ID), where the dashboard already
+    #     confirmed intent and blocking on stdin would hang the agent.
+    in_agent_session = bool(os.environ.get("WECO_CC_SESSION_ID"))
+    if (
+        not daemon
+        and output_mode != "plain"
+        and not in_agent_session
+        and not Confirm.ask(
+            "Have the source files in your working directory been kept consistent with "
+            "the parent run? Local edits will override the inherited baseline.",
+            default=True,
+        )
     ):
         console.print("[yellow]Derive cancelled. Adjust your working directory and re-run.[/]")
         return False
 
-    return _run_derived_loop(
+    if daemon:
+        # Print everything stdout-watchers (claude, cursor, the wrapper's
+        # find_run_ids) care about BEFORE forking — once we're detached,
+        # stdout is the log file.
+        print(f"Run ID: {new_run_id}", flush=True)
+        print(f"Run name: {run_info['name']}", flush=True)
+        print(f"Dashboard: {dashboard_url}", flush=True)
+        log_path = _daemonize_to_log(new_run_id)
+        if log_path is None:
+            console.print("[yellow]--daemon not supported on this platform; running in foreground.[/]")
+        else:
+            # Force plain UI in the daemonized child — Rich's ANSI escapes
+            # would pollute the log file and serve no purpose without a TTY.
+            output_mode = "plain"
+            console = Console(force_terminal=False)
+            print(f"weco run derive daemon started; log: {log_path}", flush=True)
+    elif _should_auto_open_browser(no_open):
+        open_browser(dashboard_url)
+
+    return _attach_or_consume(
         console=console,
         auth_headers=auth_headers,
         run_info=run_info,
+        lineage_id=lineage_id,
         originals=originals,
-        dashboard_url=dashboard_url,
         output_mode=output_mode,
         api_keys=api_keys,
     )

--- a/weco/commands/run/status.py
+++ b/weco/commands/run/status.py
@@ -31,6 +31,19 @@ def handle(run_id: str, console: Console) -> None:
         "pending_nodes": pending_nodes,
     }
 
+    # Just-in-time operating contract for an agent driving this run. Surfaced
+    # on the canonical progress check (not buried in a doc read once at the
+    # start) so it lands at the decision point every monitoring cycle: the run
+    # is self-driving, so stay responsive to the user and act via derive/stop.
+    if run_meta.get("status") in ("running", "pending_approval", "pending_evaluation"):
+        output["agent_guidance"] = (
+            "This run is self-driving — do NOT tail logs or use any blocking/streaming watch; "
+            "just poll this command (it returns immediately). Between polls you remain available "
+            "to the user: if they send a message, acknowledge and act on it before polling again — "
+            'steer with `weco run derive <run-id> --from-step best -i "<direction>"` (works mid-run, '
+            "no need to stop first), or abort with `weco run stop <run-id>`."
+        )
+
     # Add lineage info if present (requires full run status fetch)
     try:
         full_status = fetch_run(client, run_id, include_history=False)

--- a/weco/commands/start/__init__.py
+++ b/weco/commands/start/__init__.py
@@ -1,0 +1,5 @@
+"""`weco start` subcommands — launch tools bridged to the Weco dashboard."""
+
+from .cli import configure_start_parser, handle_start_command
+
+__all__ = ["configure_start_parser", "handle_start_command"]

--- a/weco/commands/start/approval_router.py
+++ b/weco/commands/start/approval_router.py
@@ -1,0 +1,173 @@
+"""Approval + AskUserQuestion routing for the Claude bridge.
+
+Bridges the SDK's ``can_use_tool`` callback to two surfaces — the dashboard
+(over the relay channel) and the local TUI (via orchestrator callbacks) —
+and resolves the SDK call with whichever answers first. Approvals can be
+cached per-tool or per-exact-call so a granted scope doesn't re-prompt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+from typing import Any, Callable
+
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny, ToolPermissionContext
+
+from .envelopes import summarise
+
+
+# Publishes a JSON line to the dashboard; returns False if it couldn't (queue
+# full / dropped). The router fails open — if it can't even ask, it allows.
+PublishFn = Callable[[str], bool]
+
+
+_id_seq = itertools.count(1)
+
+
+def new_id() -> str:
+    return f"weco-approval-{next(_id_seq)}"
+
+
+def cache_key(tool_name: str, tool_input: Any) -> str:
+    if not isinstance(tool_input, dict):
+        return tool_name
+    for key in ("command", "file_path", "path", "url", "query"):
+        v = tool_input.get(key)
+        if isinstance(v, str) and v:
+            return f"{tool_name}:{v}"
+    return tool_name
+
+
+class ApprovalRouter:
+    """Bridges SDK ``can_use_tool`` calls to the dashboard + local modal.
+
+    For tool approvals: publishes an ``approval_request`` envelope and
+    awaits an ``approval_response`` from any surface (dashboard channel
+    or local TUI modal).
+
+    For ``AskUserQuestion``: publishes a ``question_request`` and awaits
+    a ``question_response``; on resolution returns ``PermissionResultAllow``
+    with ``{questions, answers}`` folded into ``updated_input`` per the
+    Agent SDK contract.
+    """
+
+    def __init__(self, *, publish: PublishFn, on_approval_request=None, on_question_request=None) -> None:
+        self._publish = publish
+        # No-op defaults let unit tests construct the router without hooks.
+        self._on_approval_request = on_approval_request or (lambda *a, **k: None)
+        self._on_question_request = on_question_request or (lambda *a, **k: None)
+        self._pending_approvals: dict[str, asyncio.Future] = {}
+        self._pending_questions: dict[str, asyncio.Future] = {}
+        self._approvals: dict[str, str] = {}
+
+    async def can_use_tool(
+        self, tool_name: str, tool_input: dict[str, Any], context: ToolPermissionContext
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        if tool_name == "AskUserQuestion":
+            return await self._ask_user_question(tool_input, context)
+        return await self._tool_approval(tool_name, tool_input, context)
+
+    async def _tool_approval(
+        self, tool_name: str, tool_input: dict[str, Any], context: ToolPermissionContext
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        key = cache_key(tool_name, tool_input)
+        cached = self._approvals.get(key) or self._approvals.get(tool_name)
+        if cached == "approve":
+            return PermissionResultAllow(updated_input=tool_input)
+
+        request_id = getattr(context, "tool_use_id", None) or new_id()
+        future = asyncio.get_running_loop().create_future()
+        self._pending_approvals[request_id] = future
+        summary = summarise(tool_name, tool_input)
+
+        published = self._publish(
+            json.dumps(
+                {
+                    "type": "_weco_meta",
+                    "event": "approval_request",
+                    "id": request_id,
+                    "tool_name": tool_name,
+                    "summary": summary,
+                    "tool_input": tool_input,
+                }
+            )
+        )
+        if not published:
+            # Couldn't reach the dashboard — fail open rather than block claude.
+            self._pending_approvals.pop(request_id, None)
+            return PermissionResultAllow(updated_input=tool_input)
+
+        # Let the orchestrator pop a local modal alongside the dashboard
+        # card. Best-effort — if no local UI is wired the dashboard still
+        # resolves the future.
+        try:
+            self._on_approval_request(request_id, tool_name, summary, tool_input)
+        except Exception:
+            pass
+
+        try:
+            response = await future
+        except asyncio.CancelledError:
+            return PermissionResultDeny(message="Approval cancelled")
+
+        decision = response.get("decision", "ask")
+        scope = response.get("scope", "once")
+        if decision == "approve":
+            # "always" comes from the TUI modal's Allow-always button and is
+            # treated as a tool-wide whitelist; "tool"/"command" are the more
+            # granular scopes the dashboard sends.
+            if scope in ("tool", "always"):
+                self._approvals[tool_name] = "approve"
+            elif scope == "command":
+                self._approvals[key] = "approve"
+            return PermissionResultAllow(updated_input=tool_input)
+        return PermissionResultDeny(message=response.get("reason") or "Denied by user")
+
+    async def _ask_user_question(
+        self, tool_input: dict[str, Any], context: ToolPermissionContext
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        questions = tool_input.get("questions") if isinstance(tool_input, dict) else None
+        if not isinstance(questions, list) or not questions:
+            return PermissionResultAllow(updated_input={"questions": questions or [], "answers": {}})
+
+        request_id = getattr(context, "tool_use_id", None) or new_id()
+        future = asyncio.get_running_loop().create_future()
+        self._pending_questions[request_id] = future
+
+        published = self._publish(
+            json.dumps({"type": "_weco_meta", "event": "question_request", "id": request_id, "questions": questions})
+        )
+        if not published:
+            self._pending_questions.pop(request_id, None)
+            return PermissionResultAllow(updated_input={"questions": questions, "answers": {}})
+
+        # Surface the same question inline in the TUI; whichever surface
+        # (TUI or dashboard) answers first wins.
+        try:
+            self._on_question_request(request_id, questions)
+        except Exception:
+            pass
+
+        try:
+            response = await future
+        except asyncio.CancelledError:
+            return PermissionResultDeny(message="Question cancelled")
+
+        answers = response.get("answers")
+        if not isinstance(answers, dict):
+            answers = {}
+        return PermissionResultAllow(updated_input={"questions": questions, "answers": answers})
+
+    def resolve(self, request_id: str, decision: str, scope: str = "once") -> None:
+        future = self._pending_approvals.pop(request_id, None)
+        if future is None or future.done():
+            return
+        future.set_result({"decision": decision, "scope": scope})
+
+    def resolve_question(self, request_id: str, answers: dict[str, Any]) -> None:
+        future = self._pending_questions.pop(request_id, None)
+        if future is None or future.done():
+            return
+        future.set_result({"answers": answers})

--- a/weco/commands/start/cli.py
+++ b/weco/commands/start/cli.py
@@ -1,0 +1,117 @@
+"""`weco start claude` — run Claude Code with a bidirectional bridge to the dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+
+from rich.console import Console
+
+from weco.config import load_weco_api_key
+
+from .sdk_config import VALID_EFFORTS
+
+
+def configure_start_parser(start_parser: argparse.ArgumentParser) -> None:
+    sub = start_parser.add_subparsers(dest="start_command", help="What to start")
+
+    claude_parser = sub.add_parser(
+        "claude",
+        help="Launch Claude Code bridged to the Weco dashboard (bidirectional)",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    claude_parser.add_argument(
+        "--allow-tools",
+        action="store_true",
+        help=(
+            "Auto-approve all Claude Code tool calls (passes --dangerously-skip-permissions). "
+            "Bash, Write, Edit etc. run without prompting. Use only when you trust the agent."
+        ),
+    )
+    claude_parser.add_argument(
+        "--effort",
+        type=str,
+        choices=list(VALID_EFFORTS),
+        default=None,
+        help=(
+            "Thinking effort level. Raises the thinking-token budget so Claude returns "
+            "`thinking` content blocks alongside its response — these stream into the "
+            "dashboard's Reasoning section. Omit to inherit Claude's own default (no extra "
+            "thinking)."
+        ),
+    )
+    claude_parser.add_argument(
+        "--billing",
+        type=str,
+        choices=["claude", "weco"],
+        default="claude",
+        help=(
+            "Where LLM calls are billed. 'claude' (default) uses your local Claude auth "
+            "(OAuth from `claude login`, or `ANTHROPIC_API_KEY`) and your usage counts "
+            "against whatever credit pool Anthropic's billing applies to those credentials. "
+            "'weco' routes through Weco's LLM proxy and deducts from your Weco credit wallet "
+            "(works for any auth scheme). Choose 'weco' if you'd rather pay through Weco."
+        ),
+    )
+    claude_parser.add_argument(
+        "claude_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments to forward to claude (prefix with -- to separate from weco flags)",
+    )
+
+
+def handle_start_command(args: argparse.Namespace, console: Console) -> None:
+    sub = getattr(args, "start_command", None)
+    if sub == "claude":
+        _handle_claude(args, console)
+    else:
+        console.print("[red]Unknown start subcommand.[/]")
+        console.print("Usage: [bold]weco start claude[/]")
+        sys.exit(2)
+
+
+def _require_api_key(console: Console) -> str:
+    api_key = load_weco_api_key()
+    if not api_key:
+        console.print("[red]Not logged in.[/] Run [bold]weco login[/] first.")
+        sys.exit(1)
+    return api_key
+
+
+def _require_claude_cli(console: Console) -> None:
+    """Fail fast (before creating a session or launching the TUI) if Claude
+    Code isn't installed — `weco start claude` drives it under the hood."""
+    if shutil.which("claude"):
+        return
+    console.print(
+        "[red]Claude Code CLI not found.[/] [bold]weco start claude[/] runs Claude Code under the hood.\n"
+        "Install it, then re-run: https://code.claude.com/docs/en/quickstart"
+    )
+    sys.exit(1)
+
+
+def _strip_arg_separator(args: list[str]) -> list[str]:
+    if args and args[0] == "--":
+        return args[1:]
+    return args
+
+
+def _handle_claude(args: argparse.Namespace, console: Console) -> None:
+    api_key = _require_api_key(console)
+    _require_claude_cli(console)
+
+    forwarded = _strip_arg_separator(list(getattr(args, "claude_args", []) or []))
+    if getattr(args, "allow_tools", False) and not any(a == "--dangerously-skip-permissions" for a in forwarded):
+        forwarded.append("--dangerously-skip-permissions")
+
+    effort = getattr(args, "effort", None)
+    billing = getattr(args, "billing", "claude")
+
+    from weco import __base_url__
+    from .tui_bridge import run_tui_bridge
+
+    exit_code = run_tui_bridge(
+        claude_args=forwarded, api_key=api_key, console=console, billing=billing, weco_api_base=__base_url__, effort=effort
+    )
+    sys.exit(exit_code)

--- a/weco/commands/start/envelopes.py
+++ b/weco/commands/start/envelopes.py
@@ -1,0 +1,166 @@
+"""SDK message ↔ dashboard transcript conversion + display formatting.
+
+The dashboard consumes the same stream-json envelope shape that
+``claude -p`` emits, so its transcript parser works unchanged. These
+helpers turn the Agent SDK's typed messages into that wire shape, plus a
+few small string formatters shared by the orchestrator and approval router.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    ResultMessage,
+    StreamEvent,
+    SystemMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+
+INTERRUPT_MARKER = "Request interrupted by user"
+
+
+def envelope_for(message: Any) -> Optional[dict]:
+    """SDK message → claude stream-json envelope for the dashboard relay."""
+    if isinstance(message, StreamEvent):
+        return {
+            "type": "stream_event",
+            "event": message.event,
+            "session_id": message.session_id,
+            "parent_tool_use_id": message.parent_tool_use_id,
+        }
+    if isinstance(message, AssistantMessage):
+        msg: dict[str, Any] = {"role": "assistant", "content": [block_to_dict(b) for b in message.content]}
+        # `id` is what claude's native stream-json emits; the dashboard
+        # parser keys its streamed-vs-bulk dedupe off it.
+        if message.message_id:
+            msg["id"] = message.message_id
+        return {"type": "assistant", "message": msg, "model": message.model, "session_id": message.session_id}
+    if isinstance(message, UserMessage):
+        content = message.content
+        if isinstance(content, list):
+            content_json = [block_to_dict(b) for b in content]
+        else:
+            content_json = content
+        return {"type": "user", "message": {"role": "user", "content": content_json}}
+    if isinstance(message, SystemMessage):
+        return {"type": "system", "subtype": message.subtype, **message.data}
+    if isinstance(message, ResultMessage):
+        return {
+            "type": "result",
+            "subtype": message.subtype,
+            "duration_ms": message.duration_ms,
+            "duration_api_ms": message.duration_api_ms,
+            "is_error": message.is_error,
+            "num_turns": message.num_turns,
+            "session_id": message.session_id,
+            "stop_reason": message.stop_reason,
+            "total_cost_usd": message.total_cost_usd,
+            "usage": message.usage,
+            "result": message.result,
+        }
+    return None
+
+
+def block_to_dict(block: Any) -> dict:
+    if isinstance(block, TextBlock):
+        return {"type": "text", "text": block.text}
+    if isinstance(block, ThinkingBlock):
+        return {"type": "thinking", "thinking": block.thinking, "signature": block.signature}
+    if isinstance(block, ToolUseBlock):
+        return {"type": "tool_use", "id": block.id, "name": block.name, "input": block.input}
+    if isinstance(block, ToolResultBlock):
+        return {"type": "tool_result", "tool_use_id": block.tool_use_id, "content": block.content, "is_error": block.is_error}
+    return {"type": "unknown", "repr": repr(block)}
+
+
+def is_synthetic_interrupt_message(message: Any) -> bool:
+    """Detect the SDK's post-interrupt synthetic UserMessage.
+
+    After `client.interrupt()`, the SDK appends a UserMessage whose sole
+    content reads roughly ``[Request interrupted by user]``, then emits a
+    final ResultMessage and ends the turn. That synthetic message is an
+    internal protocol artifact — it should not render as if the user typed
+    it. Match on the marker substring so a real message that merely mentions
+    an interrupt isn't swallowed.
+    """
+    if not isinstance(message, UserMessage):
+        return False
+    content = message.content
+    if isinstance(content, str):
+        return INTERRUPT_MARKER in content
+    if isinstance(content, list):
+        for block in content:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and INTERRUPT_MARKER in text:
+                return True
+    return False
+
+
+def stringify_tool_result(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                t = item.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return ""
+
+
+def summarise(tool_name: str, tool_input: Any) -> str:
+    """A short one-line summary of a tool call for cards + approval prompts."""
+    if not isinstance(tool_input, dict):
+        return tool_name
+    for key in ("command", "file_path", "path", "url", "query", "pattern"):
+        v = tool_input.get(key)
+        if isinstance(v, str) and v:
+            return v if len(v) <= 200 else v[:197] + "…"
+    return ""
+
+
+def render_ui_context_preamble(ctx: Optional[dict]) -> str:
+    """Render a dashboard UI snapshot as a hidden ``<system-reminder>``.
+
+    Empty string when nothing's available. The dashboard's transcript
+    parser filters the reminder from the visible chat (see
+    ``isSyntheticCCInjection`` on the dashboard side). Plain key-value
+    rather than JSON so claude reads it without parsing overhead and a
+    noisy field can't blow out the user's actual prompt.
+    """
+    if not ctx:
+        return ""
+    rows: list[str] = []
+    if ctx.get("summary"):
+        rows.append(f"Run: {ctx['summary']}")
+    if ctx.get("run_id"):
+        rows.append(f"Run ID: {ctx['run_id']}")
+    if ctx.get("lineage_id"):
+        rows.append(f"Lineage: {ctx['lineage_id']}")
+    if ctx.get("step") is not None:
+        rows.append(f"Active step: {ctx['step']}")
+    if ctx.get("best_metric") is not None:
+        rows.append(f"Best metric: {ctx['best_metric']}")
+    if ctx.get("url"):
+        rows.append(f"URL: {ctx['url']}")
+    if not rows:
+        return ""
+    body = "\n".join(rows)
+    return (
+        "<system-reminder>\n"
+        "The user is currently viewing this in the Weco dashboard. Use as "
+        "context for their next prompt; don't repeat it back verbatim.\n\n"
+        f"{body}\n"
+        "</system-reminder>\n\n"
+    )

--- a/weco/commands/start/relay.py
+++ b/weco/commands/start/relay.py
@@ -1,0 +1,503 @@
+"""Low-level Supabase Realtime channel pump for the dashboard bridge.
+
+The high-level object the bridge uses is :class:`~weco.commands.start.session.DashboardSession`;
+this module is the engine it drives. ``run_channel`` opens the channel for a
+session, pumps its outbound queue to broadcasts (chunking large payloads),
+keeps the JWT fresh + the session heartbeating, replays scrollback to late
+joiners, and marks the session closed on exit. Inbound = control events from
+the dashboard (``inject_prompt``, ``approval_response``, ``scrollback_request``)
+re-synthesized into JSON-line form for the bridge dispatch code.
+
+Wire format on the channel:
+    event ``transcript``         payload ``{"line": <json-line text>, "seq": <int>}``
+    event ``transcript_chunk``   payload ``{"chunk_id", "seq", "of", "data"}``
+    event ``scrollback_replay``  payload ``{"line": <json-line>, "seq": <int>, "replay": true}``
+    event ``inject_prompt``      payload ``{"text", "id"?}``  (dashboard -> CLI)
+    event ``approval_response``  payload ``{"id", "decision", "scope"?}``
+    event ``scrollback_request`` payload ``{}``  (dashboard -> CLI)
+
+Persistence model: nothing is written to Weco servers. Transcript history lives:
+  * In-memory in this process (capped ring buffer) for replay-on-rejoin.
+  * Optionally, on the user's disk at ~/.config/weco/sessions/<id>.jsonl
+    (opt-out with ``WECO_NO_LOCAL_HISTORY=1``).
+
+The CLI is the only owner-side publisher. The dashboard sends control messages
+through the Weco API, which publishes them to the channel on the CLI's behalf.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import pathlib
+import time
+import uuid
+from collections import deque
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from typing import TYPE_CHECKING, Awaitable, Callable, Iterator, Optional, TextIO
+
+if TYPE_CHECKING:
+    from weco.core.api import WecoClient
+
+
+# --- Constants -----------------------------------------------------------------
+
+OUTBOUND_QUEUE_MAX = 2048
+
+# Supabase Realtime caps Broadcast payloads at ~3 MB; chunk anything larger.
+# The threshold is in bytes, applied to the UTF-8 encoded JSON-line string.
+MAX_PAYLOAD_BYTES = 2_500_000
+
+# JWT refresh: kick a fresh token in this many seconds before the current
+# one would otherwise expire. Set generously so a short-lived expiry stalls
+# don't drop the channel.
+JWT_REFRESH_LEAD_SECONDS = 60
+
+# In-memory scrollback ring buffer. Cap by total bytes of stored payloads;
+# drop oldest events when full. ~4 MB covers a typical Claude session;
+# enough for "user refreshed their dashboard tab" cases.
+SCROLLBACK_BUFFER_BYTES = 4 * 1024 * 1024
+
+# Coalesce scrollback replays: when one or more dashboard tabs ask for
+# history, wait a short beat and replay the buffer ONCE for all of them.
+# A replay is a broadcast every channel subscriber receives (deduped by
+# seq), so one replay serves every tab that asked within the window.
+#
+# Trailing-edge on purpose. A leading-edge throttle (serve the first
+# requester, drop everyone for the next N seconds) starves a tab that
+# takes over the session moments after another joined — it asks, gets
+# silently dropped, and shows empty history. Debouncing instead means a
+# late/takeover request always schedules its own replay.
+SCROLLBACK_REPLAY_DEBOUNCE = 1.5
+
+
+# Errors during a session (websocket disconnects, etc.) can't be printed to the
+# user's terminal because the wrapped agent owns it and our prints would corrupt
+# its TUI. Log them to a file the user can tail if they want detail.
+_LOG_DIR = pathlib.Path.home() / ".config" / "weco"
+_LOG_FILE = _LOG_DIR / "session.log"
+_SESSIONS_DIR = _LOG_DIR / "sessions"
+
+# Cap the shared diagnostics log so it can't grow without bound across runs.
+# It's low-volume (errors/info only, never the transcript), so a handful of
+# small rotations is ample: at most MAX_BYTES x (BACKUP_COUNT + 1) on disk.
+SESSION_LOG_MAX_BYTES = 5 * 1024 * 1024
+SESSION_LOG_BACKUP_COUNT = 3
+
+
+def _get_logger() -> logging.Logger:
+    logger = logging.getLogger("weco.start.relay")
+    if logger.handlers:
+        return logger
+    logger.propagate = False
+    try:
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(_LOG_FILE, maxBytes=SESSION_LOG_MAX_BYTES, backupCount=SESSION_LOG_BACKUP_COUNT)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    except OSError:
+        logger.addHandler(logging.NullHandler())
+    return logger
+
+
+logger = _get_logger()
+
+
+# --- Outbound queue helpers ----------------------------------------------------
+
+
+# Inbound handler: receives a single text frame (JSON line). Bridges parse it
+# to dispatch on the ``type`` field.
+InboundHandler = Callable[[str], Optional[Awaitable[None]]]
+
+
+def enqueue(outbound: "asyncio.Queue[str]", text: str) -> bool:
+    """Best-effort enqueue. Returns False (and drops the line) on overflow."""
+    try:
+        outbound.put_nowait(text)
+        return True
+    except asyncio.QueueFull:
+        return False
+
+
+# --- Scrollback buffer & local disk log ---------------------------------------
+
+
+class ScrollbackBuffer:
+    """Bounded in-memory buffer of recent transcript events.
+
+    Each entry is a (seq, line) pair. Total stored bytes is capped; oldest
+    entries get evicted on overflow. Used to replay history to dashboard
+    tabs that join after the session started.
+    """
+
+    def __init__(self, max_bytes: int = SCROLLBACK_BUFFER_BYTES) -> None:
+        self._items: "deque[tuple[int, str]]" = deque()
+        self._bytes = 0
+        self._max_bytes = max_bytes
+
+    def append(self, seq: int, line: str) -> None:
+        size = len(line.encode("utf-8"))
+        self._items.append((seq, line))
+        self._bytes += size
+        while self._bytes > self._max_bytes and self._items:
+            _, popped = self._items.popleft()
+            self._bytes -= len(popped.encode("utf-8"))
+
+    def snapshot(self) -> list[tuple[int, str]]:
+        return list(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+
+def _open_local_log(session_id: str) -> Optional[TextIO]:
+    """Open a per-session JSONL file under ~/.config/weco/sessions/.
+
+    Returns a writable file handle, or None if disabled or unavailable.
+    """
+    if os.environ.get("WECO_NO_LOCAL_HISTORY") == "1":
+        return None
+    try:
+        _SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        return open(_SESSIONS_DIR / f"{session_id}.jsonl", "a", buffering=1, encoding="utf-8")
+    except OSError as e:
+        logger.info("local session log disabled: %s", e)
+        return None
+
+
+# --- Realtime client -----------------------------------------------------------
+
+
+def _parse_iso(ts: str) -> float:
+    """Parse a Supabase ISO-8601 timestamp into a unix timestamp."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+
+
+def _chunk_utf8(s: str, max_bytes: int) -> Iterator[str]:
+    """Split a string into chunks whose UTF-8 encoding fits under ``max_bytes``.
+
+    Avoids splitting multi-byte sequences mid-character.
+    """
+    encoded = s.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        yield s
+        return
+    pos = 0
+    while pos < len(encoded):
+        end = min(pos + max_bytes, len(encoded))
+        # Walk back if we landed on a UTF-8 continuation byte (10xxxxxx).
+        while end > pos and end < len(encoded) and (encoded[end] & 0xC0) == 0x80:
+            end -= 1
+        yield encoded[pos:end].decode("utf-8")
+        pos = end
+
+
+async def run_channel(
+    *,
+    weco_client: "WecoClient",
+    session_data: dict,
+    outbound: "asyncio.Queue[str]",
+    on_inbound: InboundHandler,
+    stop_event: asyncio.Event,
+) -> None:
+    """Connect to the Realtime channel for ``session_data`` and pump messages.
+
+    Owns three internal tasks for the lifetime of the channel:
+      * publisher  — drains ``outbound`` to broadcasts (with chunking)
+      * refresher  — keeps the JWT fresh by minting new ones server-side
+      * heartbeater — rolls the session TTL forward
+
+    Also listens for ``scrollback_request`` events and replays the in-memory
+    buffer in response. Marks the session closed on exit. Returns when
+    ``stop_event`` is set or the connection terminates.
+    """
+    try:
+        from realtime import AsyncRealtimeClient
+    except ImportError:
+        # Logged silently; printing to TTY would corrupt the wrapped agent's UI.
+        logger.warning("realtime package not installed; dashboard bridge disabled.")
+        return
+
+    rt_creds = session_data.get("realtime") or {}
+    session_id = session_data["session"]["id"]
+    rt_url = rt_creds["url"]
+    rt_token = rt_creds["token"]
+    channel_name = rt_creds["channel"]
+    expires_at_unix = _parse_iso(rt_creds["expires_at"])
+
+    # The gateway gates the WebSocket handshake on `apikey` and rejects a user
+    # JWT there (HTTP 401). Connect with the public anon key as apikey, then
+    # authenticate the user via `set_auth(rt_token)` before subscribing — that
+    # user token is what authorizes the channel join.
+    rt_apikey = rt_creds["apikey"]
+
+    client = AsyncRealtimeClient(rt_url, rt_apikey, auto_reconnect=True)
+
+    seq_counter = {"value": 0}  # CLI-assigned monotonic seq per session
+    scrollback = ScrollbackBuffer()
+    expiry_state = {"unix": expires_at_unix}
+    replay_pending: dict = {"task": None}
+    local_log = _open_local_log(session_id)
+
+    try:
+        await client.connect()
+    except Exception as e:
+        if not stop_event.is_set():
+            logger.warning("Realtime connect failed for session %s: %s", session_id, e)
+        if local_log is not None:
+            try:
+                local_log.close()
+            except Exception:
+                pass
+        return
+
+    channel = client.channel(channel_name, {"config": {"private": True}})
+
+    # Inbound: synthesize JSON-line strings so existing bridge dispatch keeps
+    # working. The original protocol used `{"type": "inject_prompt", ...}`
+    # text frames; we re-emit that envelope from broadcast event + payload.
+    def _on_control_broadcast(event_type: str):
+        def _cb(message: dict) -> None:
+            payload = (message or {}).get("payload") or {}
+            try:
+                line = json.dumps({"type": event_type, **payload})
+            except (TypeError, ValueError):
+                return
+            result = on_inbound(line)
+            if asyncio.iscoroutine(result):
+                asyncio.create_task(result)
+
+        return _cb
+
+    channel.on_broadcast("inject_prompt", _on_control_broadcast("inject_prompt"))
+    channel.on_broadcast("approval_response", _on_control_broadcast("approval_response"))
+    # AskUserQuestion answers — Claude SDK's clarifying-question gate
+    # round-trips through the same control plane as tool approvals.
+    channel.on_broadcast("question_response", _on_control_broadcast("question_response"))
+    # Dashboard stop button — asks the CLI to abort the in-flight turn
+    # without tearing down the session (same semantics as a local Ctrl-C).
+    channel.on_broadcast("interrupt", _on_control_broadcast("interrupt"))
+    # Dashboard "Explore a new path" — structured derived-run request the
+    # bridge turns into agent instructions (not a plain chat message).
+    channel.on_broadcast("derive_request", _on_control_broadcast("derive_request"))
+
+    def _on_scrollback_request(_message: dict) -> None:
+        # A replay is already queued — it broadcasts to every subscriber,
+        # so this requester is covered. Coalesce instead of stacking.
+        if replay_pending["task"] is not None:
+            return
+
+        async def _debounced_replay() -> None:
+            try:
+                await asyncio.sleep(SCROLLBACK_REPLAY_DEBOUNCE)
+                if stop_event.is_set():
+                    return
+                await _replay_scrollback(channel, scrollback)
+            except asyncio.CancelledError:
+                raise
+            finally:
+                replay_pending["task"] = None
+
+        replay_pending["task"] = asyncio.create_task(_debounced_replay())
+
+    channel.on_broadcast("scrollback_request", _on_scrollback_request)
+
+    # Authenticate the user before joining: the channel join carries the
+    # socket's access_token, which authorizes subscribe/publish on the session's
+    # channel. The anon key in the URL only gets us past the connection
+    # handshake; it has no per-channel authority on its own.
+    try:
+        await client.set_auth(rt_token)
+    except Exception as e:
+        if not stop_event.is_set():
+            logger.warning("Realtime set_auth failed for session %s: %s", session_id, e)
+
+    try:
+        await channel.subscribe()
+    except Exception as e:
+        if not stop_event.is_set():
+            logger.warning("Realtime subscribe failed for session %s: %s", session_id, e)
+        await _safe_close(client)
+        if local_log is not None:
+            try:
+                local_log.close()
+            except Exception:
+                pass
+        return
+
+    publisher = asyncio.create_task(_publisher_loop(channel, outbound, scrollback, seq_counter, local_log, stop_event))
+    refresher = asyncio.create_task(_jwt_refresher(client, weco_client, session_id, expiry_state, stop_event))
+    heartbeater = asyncio.create_task(_heartbeat_loop(weco_client, session_id, stop_event))
+
+    try:
+        # Sleep until something tells us to stop (stop_event, or any task ending).
+        stop_task = asyncio.create_task(stop_event.wait())
+        await asyncio.wait({stop_task, publisher, refresher, heartbeater}, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        stop_event.set()
+        pending_replay = replay_pending["task"]
+        if pending_replay is not None:
+            pending_replay.cancel()
+        for t in (publisher, refresher, heartbeater):
+            t.cancel()
+        for t in (publisher, refresher, heartbeater):
+            try:
+                await asyncio.wait_for(t, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                pass
+        # Graceful-exit close: tells the Weco API the session is over so the
+        # dashboard's active list updates immediately rather than waiting for
+        # the TTL to elapse. Run in a thread so we don't block the event loop's
+        # teardown if the network is slow. Best-effort — TTL expiry is the
+        # backstop if this fails.
+        try:
+            await asyncio.to_thread(weco_client.close_session, session_id)
+        except Exception:
+            pass
+        await _safe_close(client)
+        if local_log is not None:
+            try:
+                local_log.close()
+            except Exception:
+                pass
+
+
+async def _safe_close(client) -> None:
+    try:
+        await client.close()
+    except Exception:
+        pass
+
+
+async def _publisher_loop(
+    channel,
+    outbound: "asyncio.Queue[str]",
+    scrollback: ScrollbackBuffer,
+    seq_counter: dict,
+    local_log,
+    stop_event: asyncio.Event,
+) -> None:
+    """Drain the outbound queue and publish each line as a broadcast.
+
+    Lines >MAX_PAYLOAD_BYTES are split into ``transcript_chunk`` messages with
+    a shared chunk_id; the dashboard reassembles before parsing as JSON.
+    Each line is also appended to the in-memory ring buffer (for live replay)
+    and to the optional local disk log.
+    """
+    while not stop_event.is_set():
+        try:
+            line = await asyncio.wait_for(outbound.get(), timeout=0.5)
+        except asyncio.TimeoutError:
+            continue
+
+        seq_counter["value"] += 1
+        seq = seq_counter["value"]
+
+        # Persist to in-memory buffer + local disk before broadcast — guarantees
+        # a tab that joins right after a line is sent will see it on replay,
+        # even if the broadcast itself is lost in flight.
+        scrollback.append(seq, line)
+        if local_log is not None:
+            try:
+                local_log.write(json.dumps({"seq": seq, "line": line}) + "\n")
+            except Exception as e:
+                logger.info("local log write failed: %s", e)
+
+        encoded_len = len(line.encode("utf-8"))
+        try:
+            if encoded_len <= MAX_PAYLOAD_BYTES:
+                await channel.send_broadcast("transcript", {"line": line, "seq": seq})
+            else:
+                chunk_id = uuid.uuid4().hex
+                pieces = list(_chunk_utf8(line, MAX_PAYLOAD_BYTES))
+                of = len(pieces)
+                for i, piece in enumerate(pieces):
+                    await channel.send_broadcast("transcript_chunk", {"chunk_id": chunk_id, "seq": i, "of": of, "data": piece})
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            # Don't crash the publisher on a single bad message — log and move on.
+            logger.warning("publisher send failed: %s", e)
+
+
+async def _replay_scrollback(channel, scrollback: ScrollbackBuffer) -> None:
+    """Re-broadcast every event in the buffer as ``scrollback_replay``.
+
+    Uses a distinct event name so dashboards know to dedupe against anything
+    they've already rendered live (by ``seq``). Sends sequentially to preserve
+    order; errors on individual sends are logged and skipped so one bad frame
+    can't stall the rest of the replay.
+    """
+    items = scrollback.snapshot()
+    if not items:
+        return
+    for seq, line in items:
+        try:
+            await channel.send_broadcast("scrollback_replay", {"seq": seq, "line": line, "replay": True})
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.info("scrollback replay frame failed (seq=%d): %s", seq, e)
+
+
+HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+async def _heartbeat_loop(weco_client: "WecoClient", session_id: str, stop_event: asyncio.Event) -> None:
+    """Tell the Weco API we're still alive every ~30s.
+
+    Each ping rolls the session's `expires_at` forward (the server stamps
+    `now + 2 minutes` per heartbeat). When this loop stops, the TTL elapses
+    and the server marks the session expired.
+
+    Best-effort: a failed ping is logged and we wait for the next tick.
+    The grace built into the TTL (4x the heartbeat interval) tolerates a
+    couple of consecutive failures before the session is considered stale.
+    """
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=HEARTBEAT_INTERVAL_SECONDS)
+            return  # stop_event set
+        except asyncio.TimeoutError:
+            pass
+
+        try:
+            await asyncio.to_thread(weco_client.session_heartbeat, session_id)
+        except Exception as e:
+            logger.info("heartbeat failed for session %s: %s", session_id, e)
+
+
+async def _jwt_refresher(
+    rt_client, weco_client: "WecoClient", session_id: str, expiry_state: dict, stop_event: asyncio.Event
+) -> None:
+    """Mint a new JWT before the current one expires; push it into the channel."""
+    while not stop_event.is_set():
+        now = time.time()
+        sleep_for = max(1.0, expiry_state["unix"] - now - JWT_REFRESH_LEAD_SECONDS)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=sleep_for)
+            return  # stop_event set
+        except asyncio.TimeoutError:
+            pass
+
+        try:
+            fresh = await asyncio.to_thread(weco_client.refresh_realtime_token, session_id)
+        except Exception as e:
+            logger.warning("JWT refresh failed for session %s: %s", session_id, e)
+            # Back off and retry; if expiry has passed the channel will drop and
+            # auto-reconnect on the next attempt with whatever token we have.
+            await asyncio.sleep(5.0)
+            continue
+
+        try:
+            await rt_client.set_auth(fresh["token"])
+        except Exception as e:
+            logger.warning("set_auth failed for session %s: %s", session_id, e)
+            continue
+
+        expiry_state["unix"] = _parse_iso(fresh["expires_at"])

--- a/weco/commands/start/rendering.py
+++ b/weco/commands/start/rendering.py
@@ -1,0 +1,126 @@
+"""SDK message stream → WecoTUI rendering.
+
+The dashboard side of "SDK message → wire" lives in ``envelopes``; this is
+its local-terminal twin: it turns the same Agent SDK message stream into
+``WecoTUI.post_*`` calls. It owns the small amount of token-streaming state
+needed to avoid double-rendering text that already arrived as deltas.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    ResultMessage,
+    StreamEvent,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+from weco.ui.tui import WecoTUI
+
+from .envelopes import stringify_tool_result, summarise
+
+
+class Renderer:
+    """Translates the SDK message stream into ``WecoTUI`` post_* calls."""
+
+    def __init__(self, app: WecoTUI) -> None:
+        self.app = app
+        # `streamed_message_ids` collects every message-id we've already
+        # rendered text deltas for; the trailing bulk AssistantMessage then
+        # skips those text blocks to avoid double-rendering.
+        # `current_stream_message_id` tracks the active stream so deltas can
+        # register themselves.
+        self._streamed_message_ids: set[str] = set()
+        self._current_stream_message_id: Optional[str] = None
+
+    def render(self, message: Any) -> None:
+        if isinstance(message, StreamEvent):
+            self._render_stream_event(message)
+        elif isinstance(message, AssistantMessage):
+            self._render_assistant(message)
+        elif isinstance(message, UserMessage):
+            self._render_user(message)
+        elif isinstance(message, ResultMessage):
+            self._render_result(message)
+        # SystemMessage events are forwarded to the dashboard but need no
+        # local render — the banner already shows the model.
+
+    def _render_result(self, message: ResultMessage) -> None:
+        self.app.hide_thinking()
+        sub = message.subtype or ""
+        if sub and sub != "success":
+            self.app.post_turn_end(str(sub), cost=message.total_cost_usd, duration_ms=message.duration_ms)
+
+    def _render_assistant(self, message: AssistantMessage) -> None:
+        # If deltas for this message already streamed, skip text blocks in the
+        # bulk event — otherwise the response would render twice.
+        message_id = getattr(message, "message_id", None)
+        already_streamed = bool(message_id and message_id in self._streamed_message_ids)
+
+        any_text = False
+        for block in message.content:
+            if isinstance(block, TextBlock) and block.text:
+                if already_streamed:
+                    # Tool calls still need to come through; text is the only
+                    # block kind that got pre-rendered.
+                    continue
+                self.app.hide_thinking()
+                self.app.post_assistant_delta(block.text)
+                any_text = True
+            elif isinstance(block, ToolUseBlock):
+                self.app.end_assistant_block()
+                self.app.hide_thinking()
+                name = block.name or "tool"
+                tool_input = block.input if isinstance(block.input, dict) else {}
+                self.app.post_tool_use(block.id or "", name, summarise(name, tool_input), tool_input)
+        if any_text:
+            self.app.end_assistant_block()
+
+    def _render_stream_event(self, message: StreamEvent) -> None:
+        """Render token-level deltas from `include_partial_messages`.
+
+        We only care about `content_block_delta` events of type `text_delta`;
+        tool-use streaming is left to the trailing bulk AssistantMessage so we
+        have the complete tool input for the card.
+        """
+        inner = message.event if isinstance(message.event, dict) else None
+        if not inner:
+            return
+        inner_type = inner.get("type")
+        if inner_type == "message_start":
+            msg = inner.get("message")
+            if isinstance(msg, dict) and isinstance(msg.get("id"), str):
+                self._current_stream_message_id = msg["id"]
+        elif inner_type == "content_block_start":
+            # Tokens are about to flow — drop the spinner so it doesn't sit on
+            # top of streaming output.
+            self.app.hide_thinking()
+        elif inner_type == "content_block_delta":
+            delta = inner.get("delta")
+            if isinstance(delta, dict) and delta.get("type") == "text_delta":
+                text = delta.get("text")
+                if isinstance(text, str) and text:
+                    self.app.hide_thinking()
+                    self.app.post_assistant_delta(text)
+                    if self._current_stream_message_id:
+                        self._streamed_message_ids.add(self._current_stream_message_id)
+        elif inner_type == "message_stop":
+            self._current_stream_message_id = None
+
+    def _render_user(self, message: UserMessage) -> None:
+        blocks = message.content if isinstance(message.content, list) else []
+        had_result = False
+        for block in blocks:
+            if isinstance(block, ToolResultBlock):
+                text = stringify_tool_result(block.content)
+                self.app.post_tool_result(block.tool_use_id or "", text, is_error=bool(block.is_error))
+                had_result = True
+        if had_result:
+            # Tool finished — claude will be thinking about its next response;
+            # spin until the next block arrives.
+            self.app.show_thinking()

--- a/weco/commands/start/run_watcher.py
+++ b/weco/commands/start/run_watcher.py
@@ -1,0 +1,452 @@
+"""Wrapper-side weco-run watcher.
+
+Polls ``weco run status <id>`` and emits structured update events to a caller-
+supplied notifier. The notifier renders directly to the user's terminal and
+broadcasts to the dashboard — claude is not in the loop for these pings, which
+makes them fast (no LLM round-trip), cheap (no tokens), and predictable
+(deterministic format).
+
+Each update is a dict shaped like::
+
+    {
+        "kind": "step_advance" | "new_best" | "idle" | "completed" | "errored" | "stopped" | "pending_review" | "attached",
+        "run_id": "...",
+        # Lineage root id (= the original non-derived run). For a derived
+        # sub-run this differs from `run_id`; the dashboard navigates/associates
+        # by `lineage_id` so a sub-run surfaces under its root rather than as a
+        # dead-end tab on its own id. None until the first status poll resolves it.
+        "lineage_id": "..." | None,
+        "level": "info" | "success" | "warning" | "error",
+        "text": "step 3/15 done, best still 7.51x at step 0",
+        "hints": ["weco run results <id> --top 5", ...],  # optional follow-up commands
+        # Plus event-specific fields where useful for richer dashboard rendering:
+        # current_step, total_steps, best_metric, best_step, idle_seconds, ...
+    }
+
+The wrapper renders the update locally with an icon + colour by level/kind and
+forwards it to the dashboard as a ``_weco_meta:run_update`` broadcast.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from typing import Awaitable, Callable, Optional, Union
+
+
+# Idle heartbeat: if nothing has changed for this many seconds, surface a
+# "still running, no progress yet" prompt so the user gets reassured that
+# the run hasn't quietly stalled. Re-fires every IDLE_HEARTBEAT_SECONDS while
+# state remains unchanged.
+IDLE_HEARTBEAT_SECONDS = 60.0
+
+
+# Anchored regex: `Run ID: <uuid>` on its own line is what `weco run` emits in
+# its plain output. UUID v4 by spec but we accept any 36-char hyphenated form
+# to avoid coupling to the format too tightly.
+_RUN_ID_RE = re.compile(r"^Run ID: ([0-9a-fA-F-]{36})\b", re.MULTILINE)
+
+
+# Notifier signature: receives one update dict per call. May be sync or async.
+UpdateNotifier = Callable[[dict], Union[None, Awaitable[None]]]
+
+
+def find_run_ids(text: str) -> list[str]:
+    """Return the run ids appearing in `text` (de-duplicated, in order).
+
+    Handles two input shapes:
+      - raw text (e.g. from a plain stdout dump)
+      - claude's stream-json JSONL line, where tool_result content has the
+        run-id line buried inside a JSON-escaped string (newlines as ``\\n``,
+        not real ``\\n``). We decode the JSON first and search the
+        nested string values so the anchored regex still works on real
+        newlines.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+
+    def take(s: str) -> None:
+        for match in _RUN_ID_RE.finditer(s):
+            rid = match.group(1)
+            if rid not in seen:
+                seen.add(rid)
+                out.append(rid)
+
+    # Try JSON first — the common case for stream-json.
+    try:
+        decoded = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        decoded = None
+
+    if decoded is not None:
+        _walk_strings(decoded, take)
+    else:
+        take(text)
+
+    return out
+
+
+def _walk_strings(obj, on_string) -> None:
+    """Walk a JSON-decoded value, calling ``on_string`` with each string leaf."""
+    if isinstance(obj, str):
+        on_string(obj)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _walk_strings(v, on_string)
+    elif isinstance(obj, list):
+        for v in obj:
+            _walk_strings(v, on_string)
+
+
+# Statuses that mean "stop polling".
+_TERMINAL_STATUSES = {"completed", "complete", "error", "errored", "stopped", "terminated", "cancelled"}
+
+
+class RunWatcher:
+    """Polls ``weco run status <id>`` and posts structured progress updates.
+
+    A ``RunWatcher`` may be watching multiple runs concurrently. Each watch is
+    its own asyncio task; cancelling the watcher cancels all of them.
+    """
+
+    def __init__(
+        self, *, weco_bin: Optional[str], notify: UpdateNotifier, stop_event: asyncio.Event, poll_interval_s: float = 10.0
+    ) -> None:
+        # Caller is responsible for resolution (so tests can pass None to
+        # exercise the no-bin path independent of the host's PATH).
+        self.weco_bin = weco_bin
+        self.notify = notify
+        self.stop_event = stop_event
+        self.poll_interval_s = poll_interval_s
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    def watch(self, run_id: str) -> bool:
+        """Begin watching ``run_id``. Returns True if a new watch was started,
+        False if we were already watching it."""
+        if run_id in self._tasks and not self._tasks[run_id].done():
+            return False
+        if not self.weco_bin:
+            return False
+        self._tasks[run_id] = asyncio.create_task(self._poll(run_id))
+        return True
+
+    def watching(self) -> list[str]:
+        return [rid for rid, t in self._tasks.items() if not t.done()]
+
+    async def stop(self) -> None:
+        for task in list(self._tasks.values()):
+            if not task.done():
+                task.cancel()
+        for task in list(self._tasks.values()):
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                pass
+        self._tasks.clear()
+
+    # --- Internals ---
+
+    async def _emit(self, update: Optional[dict]) -> None:
+        if not update:
+            return
+        result = self.notify(update)
+        if asyncio.iscoroutine(result):
+            await result
+
+    async def _poll(self, run_id: str) -> None:
+        last_status: Optional[str] = None
+        last_best_step: Optional[int] = None
+        last_current_step: Optional[int] = None
+        last_pending_count: Optional[int] = None
+        last_change_at = time.monotonic()
+        last_heartbeat_at = last_change_at
+        # Fire an immediate "attached" event so consumers (dashboard
+        # toast, terminal renderer) learn the run id without waiting
+        # for the first poll cycle. `build_status_change_message`
+        # suppresses the same kind on cur_step == 0 (which is almost
+        # always true at run start), so we'd otherwise wait minutes
+        # before the dashboard learns there's a new run.
+        await self._emit({"kind": "attached", "run_id": run_id, "level": "info", "text": "watching run", "hints": []})
+        try:
+            while not self.stop_event.is_set():
+                await asyncio.sleep(self.poll_interval_s)
+                status = await self._fetch_status(run_id)
+                if status is None:
+                    continue
+                cur_status = (status.get("status") or "").lower()
+                cur_best_step = status.get("best_step")
+                cur_step = status.get("current_step")
+                pending_nodes = status.get("pending_nodes") or []
+                cur_pending_count = len(pending_nodes)
+
+                changed = False
+                # Status change wins outright — covers terminal states
+                # (completed/error/stopped) and any movement out of "running".
+                if cur_status and cur_status != last_status:
+                    await self._emit(build_status_change_message(run_id, status, prev=last_status))
+                    changed = True
+                else:
+                    # Within a single status (typically "running"), fire on
+                    # whichever finer-grained signal advanced this poll. We
+                    # check best-step first so a step-with-improvement reads
+                    # as the more interesting message rather than a generic
+                    # progress tick.
+                    update: Optional[dict] = None
+                    if cur_best_step is not None and last_best_step is not None and cur_best_step != last_best_step:
+                        update = build_new_best_message(run_id, status)
+                        changed = True
+                    elif cur_step is not None and last_current_step is not None and cur_step != last_current_step:
+                        update = build_step_advance_message(run_id, status)
+                        changed = True
+                    elif last_pending_count is not None and cur_pending_count > last_pending_count:
+                        update = build_pending_review_message(run_id, status)
+                        changed = True
+                    await self._emit(update)
+
+                now = time.monotonic()
+                if changed:
+                    last_change_at = now
+                    last_heartbeat_at = now
+                elif (
+                    cur_status == "running"
+                    and now - last_change_at >= IDLE_HEARTBEAT_SECONDS
+                    and now - last_heartbeat_at >= IDLE_HEARTBEAT_SECONDS
+                ):
+                    await self._emit(build_idle_heartbeat_message(run_id, status, idle_seconds=now - last_change_at))
+                    last_heartbeat_at = now
+
+                last_status = cur_status
+                if cur_best_step is not None:
+                    last_best_step = cur_best_step
+                if cur_step is not None:
+                    last_current_step = cur_step
+                last_pending_count = cur_pending_count
+                if cur_status in _TERMINAL_STATUSES:
+                    return
+        except asyncio.CancelledError:
+            return
+
+    async def _fetch_status(self, run_id: str) -> Optional[dict]:
+        if not self.weco_bin:
+            return None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.weco_bin, "run", "status", run_id, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                return None
+        except (FileNotFoundError, OSError):
+            return None
+        try:
+            return json.loads(stdout.decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+
+
+# --- Update builders -----------------------------------------------------------
+#
+# Each returns a dict shaped per the module docstring, or None if there isn't
+# enough information in `status` to construct a meaningful update.
+
+
+def _format_metric(value) -> str:
+    """Render a numeric metric compactly (3 sig figs, strip trailing zeros)."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if f == int(f):
+        return f"{int(f)}"
+    return f"{f:.3g}"
+
+
+def _progress_str(cur_step, total) -> str:
+    if cur_step is None:
+        return ""
+    if total is None:
+        return f"step {cur_step}"
+    return f"step {cur_step}/{total}"
+
+
+def _best_clause(best, best_step) -> str:
+    if best is None or best_step is None:
+        return ""
+    return f"best {_format_metric(best)} at step {best_step}"
+
+
+def build_new_best_message(run_id: str, status: dict) -> Optional[dict]:
+    """User-direct update for a new best metric."""
+    best = status.get("best_metric")
+    best_step = status.get("best_step")
+    cur_step = status.get("current_step")
+    total = status.get("total_steps")
+    if best is None or best_step is None:
+        return None
+    progress = _progress_str(cur_step, total)
+    progress_part = f" ({progress})" if progress else ""
+    return {
+        "kind": "new_best",
+        "run_id": run_id,
+        "lineage_id": status.get("lineage_id"),
+        "level": "success",
+        "text": f"new best {_format_metric(best)} at step {best_step}{progress_part}",
+        "hints": [],
+        "current_step": cur_step,
+        "total_steps": total,
+        "best_metric": best,
+        "best_step": best_step,
+    }
+
+
+def build_step_advance_message(run_id: str, status: dict) -> Optional[dict]:
+    """User-direct update for a generic step transition (no improvement)."""
+    cur_step = status.get("current_step")
+    total = status.get("total_steps")
+    if cur_step is None:
+        return None
+    best = status.get("best_metric")
+    best_step = status.get("best_step")
+    progress = _progress_str(cur_step, total)
+    bc = _best_clause(best, best_step)
+    text = f"{progress} done"
+    if bc:
+        text += f" — {bc}"
+    return {
+        "kind": "step_advance",
+        "run_id": run_id,
+        "lineage_id": status.get("lineage_id"),
+        "level": "info",
+        "text": text,
+        "hints": [],
+        "current_step": cur_step,
+        "total_steps": total,
+        "best_metric": best,
+        "best_step": best_step,
+    }
+
+
+def build_idle_heartbeat_message(run_id: str, status: dict, *, idle_seconds: float) -> Optional[dict]:
+    """User-direct update when the run has been quiet for a while."""
+    cur_step = status.get("current_step")
+    total = status.get("total_steps")
+    best = status.get("best_metric")
+    best_step = status.get("best_step")
+    idle_mins = max(1, int(round(idle_seconds / 60)))
+    plural = "minute" if idle_mins == 1 else "minutes"
+    progress = _progress_str(cur_step, total)
+    progress_part = f" ({progress})" if progress else ""
+    bc = _best_clause(best, best_step)
+    bc_part = f" — {bc}" if bc else ""
+    return {
+        "kind": "idle",
+        "run_id": run_id,
+        "lineage_id": status.get("lineage_id"),
+        "level": "info",
+        "text": f"still running{progress_part}, no progress in ~{idle_mins} {plural}{bc_part}",
+        "hints": [],
+        "current_step": cur_step,
+        "total_steps": total,
+        "best_metric": best,
+        "best_step": best_step,
+        "idle_seconds": idle_seconds,
+    }
+
+
+def build_pending_review_message(run_id: str, status: dict) -> Optional[dict]:
+    """User-direct update when nodes are awaiting review/evaluation."""
+    pending = status.get("pending_nodes") or []
+    if not pending:
+        return None
+    count = len(pending)
+    plural = "node" if count == 1 else "nodes"
+    return {
+        "kind": "pending_review",
+        "run_id": run_id,
+        "lineage_id": status.get("lineage_id"),
+        "level": "warning",
+        "text": f"{count} {plural} awaiting review",
+        "hints": [f"weco run review {run_id}"],
+        "pending_count": count,
+    }
+
+
+def build_status_change_message(run_id: str, status: dict, *, prev: Optional[str]) -> Optional[dict]:
+    """User-direct update for a status delta. Pulled out of ``RunWatcher`` so it
+    can be unit-tested without touching async machinery."""
+    cur = (status.get("status") or "").lower()
+    if not cur:
+        return None
+    best = status.get("best_metric")
+    best_step = status.get("best_step")
+    cur_step = status.get("current_step")
+    total = status.get("total_steps")
+
+    progress = _progress_str(cur_step, total)
+    progress_part = f" ({progress})" if progress else ""
+    bc = _best_clause(best, best_step)
+    bc_part = f" — {bc}" if bc else ""
+
+    if cur in ("completed", "complete"):
+        return {
+            "kind": "completed",
+            "run_id": run_id,
+            "lineage_id": status.get("lineage_id"),
+            "level": "success",
+            "text": f"run completed{progress_part}{bc_part}",
+            "hints": [f"weco run results {run_id} --top 5", f"weco run diff {run_id} --step best"],
+            "current_step": cur_step,
+            "total_steps": total,
+            "best_metric": best,
+            "best_step": best_step,
+        }
+    if cur in ("error", "errored"):
+        return {
+            "kind": "errored",
+            "run_id": run_id,
+            "lineage_id": status.get("lineage_id"),
+            "level": "error",
+            "text": f"run errored{progress_part}{bc_part}",
+            "hints": [f"weco run status {run_id}"],
+            "current_step": cur_step,
+            "total_steps": total,
+            "best_metric": best,
+            "best_step": best_step,
+        }
+    if cur in ("stopped", "terminated", "cancelled"):
+        return {
+            "kind": "stopped",
+            "run_id": run_id,
+            "lineage_id": status.get("lineage_id"),
+            "level": "warning",
+            "text": f"run stopped (status: {cur}){progress_part}{bc_part}",
+            "hints": [f"weco resume {run_id} --daemon"],
+            "current_step": cur_step,
+            "total_steps": total,
+            "best_metric": best,
+            "best_step": best_step,
+        }
+    if prev is None:
+        # First observation of a non-terminal status. `_poll` already emitted
+        # an immediate `attached` event for run pickup, so don't announce a
+        # second one here — progress flows via step_advance / new_best / idle.
+        return None
+    # Generic running-state transition.
+    if cur == "running" and cur != prev:
+        return {
+            "kind": "attached",
+            "run_id": run_id,
+            "lineage_id": status.get("lineage_id"),
+            "level": "info",
+            "text": f"now {cur}{progress_part}{bc_part}",
+            "hints": [],
+            "current_step": cur_step,
+            "total_steps": total,
+            "best_metric": best,
+            "best_step": best_step,
+        }
+    return None

--- a/weco/commands/start/sdk_config.py
+++ b/weco/commands/start/sdk_config.py
@@ -1,0 +1,174 @@
+"""Translating `weco start claude` inputs into Claude Agent SDK configuration.
+
+Owns the three things we hand the SDK before connecting: the parsed
+``claude_args``, the subprocess env (which encodes the billing route), and
+the system-prompt delta we append to Claude Code's preset.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+
+# `effort` strings the SDK accepts, in display order. Shared with the
+# argparse `--effort` choices so the CLI and the SDK agree on one list.
+VALID_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
+
+
+# Appended to claude's built-in Claude Code system prompt (we don't replace
+# it — `preset: "claude_code"` keeps the baseline). Keeps the agent aware
+# that it's running inside a Weco bridge and that the `weco` skill is the
+# canonical entry point for anything Weco-related.
+WECO_SYSTEM_PROMPT_APPEND = """\
+You are running inside a Weco-bridged Claude Code session. The user is a Weco
+user; they may be on a run-detail page in the Weco dashboard while talking
+to you (a `<system-reminder>` block at the start of any prompt will give you
+the current view: run id, lineage, step, best metric).
+
+For any Weco-related operation — running an optimization, configuring an
+evaluator, tuning a prompt or skill against a measurable metric, or anything
+that involves Weco's optimization machinery — use the `/weco` skill rather
+than writing ad-hoc loops or scripts yourself. The skill wraps Weco's
+evaluation + search loop correctly; reinventing it is almost always wrong.
+
+Load the `/weco` skill BEFORE running any `weco` command. The skill carries
+the canonical workflow — how to start a run, monitor it without blocking,
+steer with `derive`, and read results — and a bare `weco` invocation without
+it almost always goes wrong. So before you run ANY `weco …` shell command
+(`weco run`, `weco run derive`, `weco run status`, `weco run stop`,
+`weco run results`, `weco resume`, …), make sure the `/weco` skill is loaded
+in this session; if you have not already invoked it, invoke `/weco` first and
+follow its guidance.
+"""
+
+
+async def keep_stream_open_hook(input_data, tool_use_id, context):
+    """PreToolUse no-op hook that keeps the SDK's streaming-mode input
+    channel open long enough for can_use_tool to fire — documented
+    workaround in the Agent SDK docs."""
+    return {"continue_": True}
+
+
+# Default model for `weco start claude` when the user doesn't pass `--model`.
+# Opus 4.7 is the strongest agent model; the Weco-billing proxy pins Claude
+# traffic to the first-party Anthropic API, which serves this id.
+DEFAULT_MODEL = "claude-opus-4-7"
+
+
+def peek_model(args: list[str]) -> Optional[str]:
+    """Cheap scan for ``--model VALUE``. ``None`` if absent (caller applies
+    `DEFAULT_MODEL`)."""
+    for i, a in enumerate(args):
+        if a == "--model" and i + 1 < len(args):
+            return args[i + 1]
+        if a.startswith("--model="):
+            return a.split("=", 1)[1]
+    return None
+
+
+def resolve_model(args: list[str]) -> str:
+    """The model the session will actually run on: an explicit `--model`,
+    else `DEFAULT_MODEL`. Used for both the SDK options and the banner so
+    they never disagree."""
+    return peek_model(args) or DEFAULT_MODEL
+
+
+def parse_claude_args(args: list[str]) -> tuple[dict[str, Any], dict[str, Optional[str]]]:
+    """Return ({recognized_fields}, {extra_args_for_sdk}).
+
+    Recognized: ``--model VALUE``, ``--effort VALUE``,
+    ``--dangerously-skip-permissions``. Everything else passes through to
+    the SDK's ``extra_args`` dict.
+    """
+    parsed: dict[str, Any] = {}
+    extra: dict[str, Optional[str]] = {}
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--model" and i + 1 < len(args):
+            parsed["model"] = args[i + 1]
+            i += 2
+            continue
+        if a == "--effort" and i + 1 < len(args):
+            parsed["effort"] = args[i + 1]
+            i += 2
+            continue
+        if a == "--dangerously-skip-permissions":
+            parsed["dangerously_skip_permissions"] = True
+            i += 1
+            continue
+        if a.startswith("--"):
+            key = a[2:]
+            if "=" in key:
+                k, _, v = key.partition("=")
+                extra[k] = v
+            elif i + 1 < len(args) and not args[i + 1].startswith("--"):
+                extra[key] = args[i + 1]
+                i += 2
+                continue
+            else:
+                extra[key] = None
+        i += 1
+    return parsed, extra
+
+
+def build_sdk_env(*, billing: str, api_key: str, weco_api_base: Optional[str], session_id: Optional[str]) -> dict[str, str]:
+    """Construct the env the SDK subprocess sees.
+
+    For ``--billing weco``, the Anthropic BASE_URL is pointed at Weco's
+    proxy (with the session id encoded in the path so the proxy can
+    broadcast ``credits_updated`` to the right channel), and the user's
+    Weco API key is used as the bearer. The proxy resolves the key to the
+    user, charges credits, and forwards the request to the model provider.
+
+    For ``--billing claude``, the SDK runs against Anthropic directly.
+    The Claude Code CLI binary (which the SDK subprocesses out to) will
+    use, in order of precedence:
+
+      1. ``ANTHROPIC_API_KEY`` if set (BYO API-key flow).
+      2. OAuth credentials stored locally by ``claude login`` otherwise.
+
+    We sanitize the inherited env so a previous ``--billing weco`` run
+    (or an explicit override in the user's shell pointing at our proxy)
+    can't accidentally re-route the call back through Weco:
+
+      * Drop ``ANTHROPIC_BASE_URL`` if it points at our proxy.
+      * Drop ``ANTHROPIC_API_KEY`` if it's a Weco key (``weco-…``) —
+        Anthropic would reject it, and the user almost certainly wants
+        their ``claude login`` OAuth credentials to kick in instead.
+
+    Genuine BYO setup (a real ``sk-ant-…`` key, or a non-Weco custom
+    BASE_URL for an Anthropic-compatible gateway) is left untouched.
+
+    ``weco_api_base`` should be the full Weco API base URL including the
+    version segment (e.g. ``https://api.weco.ai/v1``).
+    """
+    env = dict(os.environ)
+    # Signal to nested `weco` CLI invocations (e.g. `weco run` kicked off
+    # by the agent) that they're running inside a `weco start` session, so
+    # they suppress their own `webbrowser.open()` — the attached dashboard
+    # surfaces the new run via an in-page toast instead.
+    if session_id:
+        env["WECO_CC_SESSION_ID"] = session_id
+    if billing == "weco" and weco_api_base:
+        base = weco_api_base.rstrip("/")
+        # Encode session id as a path segment rather than a header — the
+        # Anthropic Python SDK doesn't honor `ANTHROPIC_CUSTOM_HEADERS`,
+        # so the proxy reads the id off the URL instead.
+        if session_id:
+            env["ANTHROPIC_BASE_URL"] = f"{base}/llm/anthropic/s/{session_id}"
+        else:
+            env["ANTHROPIC_BASE_URL"] = f"{base}/llm/anthropic"
+        env["ANTHROPIC_API_KEY"] = api_key
+        return env
+
+    if billing == "claude":
+        weco_base_marker = (weco_api_base or "").rstrip("/")
+        cur_base = env.get("ANTHROPIC_BASE_URL", "")
+        if weco_base_marker and cur_base.startswith(weco_base_marker):
+            env.pop("ANTHROPIC_BASE_URL", None)
+        cur_key = env.get("ANTHROPIC_API_KEY", "")
+        if cur_key.startswith("weco-"):
+            env.pop("ANTHROPIC_API_KEY", None)
+    return env

--- a/weco/commands/start/session.py
+++ b/weco/commands/start/session.py
@@ -1,0 +1,92 @@
+"""``DashboardSession`` — a live bridge between a local agent and the Weco dashboard.
+
+Wraps the REST session row (via :class:`~weco.core.api.WecoClient`) and its
+Supabase Realtime channel behind a four-call surface: ``create`` / ``offline``,
+``publish``, ``run``, plus ``id`` / ``dashboard_url``. JWT refresh, heartbeat,
+scrollback replay, payload chunking and graceful close all happen inside —
+callers never see api keys, queues, or channel credentials.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import requests
+
+from weco.core.api import WecoClient
+
+from . import relay
+from .relay import OUTBOUND_QUEUE_MAX, InboundHandler, enqueue
+
+
+class SetupError(Exception):
+    """Raised when the dashboard session can't be created (HTTP/network)."""
+
+
+class DashboardSession:
+    """A dashboard-bridged agent session.
+
+    Construct with :meth:`create` (which does the REST handshake) or
+    :meth:`offline` (a no-op stand-in when the relay is unavailable). Start
+    the channel with :meth:`run`; push transcript/meta JSON lines with
+    :meth:`publish`.
+    """
+
+    def __init__(self, *, client: Optional[WecoClient], data: dict) -> None:
+        self._client = client
+        self._data = data  # Weco API response, or {} when offline
+        self._outbound: asyncio.Queue[str] = asyncio.Queue(maxsize=OUTBOUND_QUEUE_MAX)
+
+    @classmethod
+    def create(cls, *, api_key: str, agent_type: str) -> "DashboardSession":
+        """REST-create the session. Raises :class:`SetupError` on failure."""
+        client = WecoClient({"Authorization": f"Bearer {api_key}"})
+        try:
+            data = client.create_session(agent_type)
+        except requests.HTTPError as e:
+            resp = e.response
+            detail = (resp.text or "")[:200] if resp is not None else str(e)
+            status = resp.status_code if resp is not None else "?"
+            raise SetupError(f"HTTP {status}: {detail}") from e
+        except requests.RequestException as e:
+            raise SetupError(str(e)) from e
+        return cls(client=client, data=data)
+
+    @classmethod
+    def offline(cls) -> "DashboardSession":
+        """A no-op session: ``publish`` drops, ``run`` returns immediately, and
+        the id/url are ``None``. Lets bridges skip ``if session`` checks."""
+        return cls(client=None, data={})
+
+    @property
+    def online(self) -> bool:
+        return self._client is not None and bool(self._data)
+
+    @property
+    def id(self) -> Optional[str]:
+        return (self._data.get("session") or {}).get("id")
+
+    @property
+    def dashboard_url(self) -> Optional[str]:
+        return self._data.get("dashboard_url")
+
+    def publish(self, line: str) -> bool:
+        """Queue a JSON line for broadcast to the dashboard. Returns False if
+        the outbound queue is full (the line is dropped). Offline sessions
+        accept lines into an undrained queue, same as the legacy behaviour."""
+        return enqueue(self._outbound, line)
+
+    async def run(self, *, on_inbound: InboundHandler, stop_event: asyncio.Event) -> None:
+        """Open the Realtime channel and pump until ``stop_event`` is set.
+        No-op for an offline session."""
+        if not self.online:
+            return
+        assert self._client is not None  # online ⇒ client present
+        await relay.run_channel(
+            weco_client=self._client,
+            session_data=self._data,
+            outbound=self._outbound,
+            on_inbound=on_inbound,
+            stop_event=stop_event,
+        )

--- a/weco/commands/start/tui_bridge.py
+++ b/weco/commands/start/tui_bridge.py
@@ -1,0 +1,840 @@
+"""TUI + Claude Agent SDK orchestration for `weco start claude`.
+
+Architecture:
+
+    user prompt (TUI input)        dashboard inject_prompt
+                │                              │
+                └──────────┬───────────────────┘
+                           ▼
+                    pending_prompts queue
+                           │
+                           ▼
+              ClaudeSDKClient (persistent)
+                           │            ▲
+        ┌──────────────────┼────────────┘
+        │                  │
+        │              can_use_tool ─► ApprovalRouter ─► outbound (dashboard)
+        │                  ▲                                        │
+        │                  │                                        ▼
+        │              resolve(id, …) ◄────── on_inbound ◄── channel relay
+        │                                                           │
+        │  ┌─────────────────────────────────────────── inline ApprovalCard
+        │  ▼                                                       (local TUI)
+        │  app.mount_inline_card(...)   ◄── same picker as AskUserQuestion
+        │
+        ▼
+   async for message ─► envelope + render to TUI (Renderer)
+
+Companion modules:
+  * ``relay``           — session create / Realtime channel / heartbeat.
+  * ``sdk_config``      — claude_args parsing, billing env, system prompt.
+  * ``envelopes``       — SDK message → dashboard transcript conversion.
+  * ``rendering``       — SDK message → local TUI post_* calls.
+  * ``approval_router`` — can_use_tool ↔ dashboard + local-modal routing.
+
+Billing: when ``--billing weco`` is passed, the SDK's HTTP traffic is
+pointed at the Weco LLM proxy (see ``sdk_config``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shlex
+import shutil
+import signal
+from typing import Any, Callable, Optional
+
+from rich.console import Console
+
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, CLINotFoundError, HookMatcher
+from claude_agent_sdk.types import ResultMessage, ToolResultBlock, UserMessage
+
+from weco.ui.tui import WecoTUI
+from weco.ui.tui.approval import ApprovalCard
+from weco.ui.tui.question import QuestionCard
+
+from .approval_router import ApprovalRouter
+from .session import DashboardSession, SetupError
+from .envelopes import envelope_for, is_synthetic_interrupt_message, render_ui_context_preamble, stringify_tool_result
+from .rendering import Renderer
+from .run_watcher import RunWatcher, find_run_ids
+from .sdk_config import (
+    VALID_EFFORTS,
+    WECO_SYSTEM_PROMPT_APPEND,
+    build_sdk_env,
+    keep_stream_open_hook,
+    parse_claude_args,
+    resolve_model,
+)
+
+
+# Wire protocol -------------------------------------------------------------
+META_TYPE = "_weco_meta"  # envelope `type` for Weco's out-of-band control traffic
+AGENT_TYPE = "claude-code"  # session kind registered with the Weco API
+# Keys the dashboard may bundle as per-turn UI context on `inject_prompt`.
+UI_CONTEXT_KEYS = ("run_id", "lineage_id", "step", "best_metric", "summary", "url")
+# Tool-approval decisions the dashboard is allowed to send.
+VALID_DECISIONS = ("approve", "deny", "ask")
+
+# Teardown / buffering knobs ------------------------------------------------
+STDERR_BUFFER_LINES = 64  # tail of SDK-subprocess stderr kept for crash diagnostics
+TASK_SHUTDOWN_TIMEOUT_S = 2.0  # grace for relay tasks to drain on shutdown
+RUN_STOP_TIMEOUT_S = 5.0  # grace for a `weco run stop` subprocess on exit
+
+# System prompt handed to the SDK: claude's own Claude Code preset plus our
+# Weco-bridge delta (append, don't replace — that keeps native behaviour).
+SYSTEM_PROMPT = {"type": "preset", "preset": "claude_code", "append": WECO_SYSTEM_PROMPT_APPEND}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — called from cli.py.
+# ---------------------------------------------------------------------------
+
+
+def run_tui_bridge(
+    *,
+    claude_args: list[str],
+    api_key: str,
+    console: Console,
+    billing: str = "claude",
+    weco_api_base: Optional[str] = None,
+    effort: Optional[str] = None,
+) -> int:
+    """Boot the TUI and the SDK-driven orchestrator."""
+    try:
+        session = DashboardSession.create(api_key=api_key, agent_type=AGENT_TYPE)
+    except SetupError as e:
+        console.print(f"[red]Could not create dashboard session:[/] {e}")
+        console.print("[yellow]Falling back to a plain local Claude Code session.[/]")
+        session = DashboardSession.offline()
+
+    app = WecoTUI()
+    orchestrator = Orchestrator(
+        app=app,
+        claude_args=claude_args,
+        api_key=api_key,
+        session=session,
+        billing=billing,
+        weco_api_base=weco_api_base,
+        effort=effort,
+    )
+
+    app.set_submit_callback(orchestrator.on_user_submit)
+    app.set_startup_callback(lambda _app: orchestrator.run())
+    app.set_preempt_callback(orchestrator.on_user_preempt)
+    app.set_exit_with_stop_callback(orchestrator.on_exit_stop_runs)
+
+    app.run()
+    return orchestrator.exit_code
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — owns the SDK client + WS relay + run watcher + approvals.
+# ---------------------------------------------------------------------------
+
+
+class Orchestrator:
+    def __init__(
+        self,
+        *,
+        app: WecoTUI,
+        claude_args: list[str],
+        api_key: str,
+        session: DashboardSession,
+        billing: str,
+        weco_api_base: Optional[str],
+        effort: Optional[str],
+    ) -> None:
+        self.app = app
+        self.claude_args = claude_args
+        self.api_key = api_key
+        self._session = session
+        self.billing = billing
+        self.weco_api_base = weco_api_base
+        self.effort = effort
+
+        self.session_id: Optional[str] = session.id
+        self.dashboard_url: Optional[str] = session.dashboard_url
+
+        self.exit_code: int = 0
+        self._renderer = Renderer(app)
+        self._stop_event = asyncio.Event()
+        # (prompt_text, ui_context_or_none). Dashboard-submitted prompts ride
+        # with the dashboard's current view snapshot bundled in the
+        # inject_prompt payload; TUI prompts carry None.
+        # (prompt, ui_context, echo_user). `echo_user=False` suppresses the
+        # user-bubble mirror to the dashboard transcript — used for structured
+        # requests (e.g. derive_request) that surface as their own meta card.
+        self._pending_prompts: asyncio.Queue[tuple[str, Optional[dict], bool]] = asyncio.Queue()
+        self._tasks: list[asyncio.Task] = []
+        self._run_watcher: Optional[RunWatcher] = None
+        self._approval_router: Optional[ApprovalRouter] = None
+        # Persistent SDK client. One long-lived consumer drains the SDK message
+        # stream (see `_consume_messages`); prompts are fed in separately via
+        # `_prompt_pump`/query(). Cancel paths (SIGINT, dashboard 'interrupt',
+        # mid-turn inject_prompt preemption, local Esc) send client.interrupt()
+        # and let the consumer drain the interrupted turn's tail in order.
+        self._sdk_client: Optional[ClaudeSDKClient] = None
+        # Count of submitted prompt-turns not yet terminated by a ResultMessage.
+        # > 0 means a user-prompted turn is in flight (so a preempt should
+        # interrupt). Incremented on a successful query(), decremented by the
+        # consumer on each ResultMessage.
+        self._inflight_turns: int = 0
+        # Set while an SDK interrupt is mid-flight and we're letting the
+        # in-flight turn drain naturally. Lets repeated cancel attempts
+        # early-out so a second SIGINT escalates to "exit" instead of
+        # re-firing a no-op interrupt. Cleared by the consumer when it sees the
+        # interrupted turn's terminal ResultMessage.
+        self._interrupting: bool = False
+        # request_id → inline card, so the bridge can dismiss the local card
+        # when the dashboard answers first OR when the SDK turn is cancelled.
+        # The `_inflight` sets de-dup a single approval bouncing through
+        # can_use_tool more than once.
+        self._approval_card_inflight: set[str] = set()
+        self._active_approval_cards: dict[str, Any] = {}
+        self._question_card_inflight: set[str] = set()
+        self._active_question_cards: dict[str, Any] = {}
+        # SDK subprocess stderr tail — the TUI owns the terminal so the raw
+        # `claude` child's stderr is invisible; we surface it via system
+        # notices on connect/run failures.
+        self._sdk_stderr_buf: list[str] = []
+
+    # --- Meta-envelope helper -------------------------------------------
+
+    def _emit_meta(self, event: str, **fields: Any) -> None:
+        """Publish a Weco control/meta envelope to the dashboard."""
+        self._session.publish(json.dumps({"type": META_TYPE, "event": event, **fields}))
+
+    # --- App startup callback -------------------------------------------
+
+    def run(self) -> None:
+        """Top-level startup callback. Scheduled by WecoTUI once the app
+        is mounted. Post the banner first so it's visible before any async
+        lifecycle work, then kick off the orchestrator."""
+        self.app.post_banner(
+            agent="Claude Code", model=resolve_model(self.claude_args), billing=self.billing, session_id=self.session_id
+        )
+        if not self.dashboard_url:
+            self.app.post_system_notice("Running without dashboard relay.", style="dim yellow")
+        asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        try:
+            await self._setup_and_loop()
+        finally:
+            await self._shutdown()
+
+    async def _setup_and_loop(self) -> None:
+        self._emit_meta("claude_session_started")
+
+        self._run_watcher = RunWatcher(
+            weco_bin=shutil.which("weco"), notify=self._notify_run_update, stop_event=self._stop_event
+        )
+
+        self._approval_router = ApprovalRouter(
+            publish=self._session.publish,
+            on_approval_request=self._on_approval_request,
+            on_question_request=self._on_question_request,
+        )
+
+        # No-op for an offline session (returns immediately).
+        self._tasks.append(
+            asyncio.create_task(self._session.run(on_inbound=self._handle_inbound, stop_event=self._stop_event))
+        )
+
+        # SIGINT handling: 1st press cancels the in-flight turn; 2nd press
+        # within the window exits and stops watched runs. The TUI's ctrl_c
+        # handler owns the primary UX (set_exit_with_stop_callback); this
+        # only fires if the user is somehow outside the TUI capture.
+        try:
+            asyncio.get_running_loop().add_signal_handler(signal.SIGINT, self._on_sigint)
+        except (NotImplementedError, RuntimeError):
+            pass
+
+        self._sdk_client = ClaudeSDKClient(options=self._build_options())
+        try:
+            await self._sdk_client.connect()
+        except CLINotFoundError:
+            # Backstop for the pre-flight `which claude` check (start/cli.py):
+            # covers the binary vanishing between check and launch.
+            self.app.post_system_notice(
+                "Claude Code CLI not found — install it "
+                "(https://code.claude.com/docs/en/quickstart), then re-run `weco start claude`.",
+                style="bold red",
+            )
+            self._stop_event.set()
+            return
+        except Exception as e:
+            self.app.post_system_notice(f"Could not connect to Claude SDK: {e}", style="bold red")
+            # The SDK's wrapped error usually says "Check stderr output for
+            # details" — surface the captured stderr so the user can diagnose
+            # without --debug-stderr.
+            stderr_blob = "".join(self._sdk_stderr_buf).strip()
+            if stderr_blob:
+                self.app.post_system_notice(f"claude stderr:\n{stderr_blob}", style="dim red")
+            self._stop_event.set()
+            return
+
+        # Start the single long-lived stream consumer, then feed prompts. The
+        # consumer fans out every message (prompted AND between-turn) the instant
+        # the SDK surfaces it; the pump only submits query()s. This is the SDK's
+        # blessed streaming pattern and is what keeps autonomous output (e.g.
+        # background-task completions, scheduled wakeups) from being stranded in
+        # the transport until the next prompt drains it.
+        self._tasks.append(asyncio.create_task(self._consume_messages()))
+        await self._prompt_pump()
+
+    def _build_options(self) -> ClaudeAgentOptions:
+        parsed_args, extra_args = parse_claude_args(self.claude_args)
+        effort = self.effort or parsed_args.get("effort")
+        permission_mode = "bypassPermissions" if parsed_args.get("dangerously_skip_permissions") else None
+        sdk_env = build_sdk_env(
+            billing=self.billing, api_key=self.api_key, weco_api_base=self.weco_api_base, session_id=self.session_id
+        )
+        return ClaudeAgentOptions(
+            can_use_tool=self._approval_router.can_use_tool,
+            # PreToolUse no-op hook keeps the SDK's input channel open long
+            # enough for can_use_tool to fire — documented SDK workaround.
+            hooks={"PreToolUse": [HookMatcher(matcher=None, hooks=[keep_stream_open_hook])]},
+            env=sdk_env,
+            model=resolve_model(self.claude_args),
+            effort=effort if effort in VALID_EFFORTS else None,  # type: ignore[arg-type]
+            permission_mode=permission_mode,  # type: ignore[arg-type]
+            extra_args=extra_args,
+            # Token-level streaming. The SDK yields `StreamEvent` objects
+            # alongside the usual message stream; the Renderer consumes their
+            # `content_block_delta` text deltas in real time.
+            include_partial_messages=True,
+            stderr=self._capture_sdk_stderr,
+            # Anchor the agent at the directory the user launched from —
+            # without this the SDK's default cwd grounds claude's project-root
+            # detection above the user's actual project.
+            cwd=os.getcwd(),
+            system_prompt=SYSTEM_PROMPT,  # type: ignore[arg-type]
+        )
+
+    async def _shutdown(self) -> None:
+        self._stop_event.set()
+        if self._sdk_client is not None:
+            try:
+                await self._sdk_client.disconnect()
+            except Exception:
+                pass
+            self._sdk_client = None
+        for task in self._tasks:
+            task.cancel()
+        for task in self._tasks:
+            try:
+                await asyncio.wait_for(task, timeout=TASK_SHUTDOWN_TIMEOUT_S)
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._run_watcher is not None:
+            await self._run_watcher.stop()
+
+    # --- User → bridge ---------------------------------------------------
+
+    async def on_user_submit(self, text: str) -> None:
+        if not text:
+            return
+        if self._cancel_current_turn():
+            self.app.post_system_notice("(interrupting current turn — your prompt will run next)", style="dim yellow")
+        # TUI prompt — no dashboard context (the user is typing into the
+        # terminal, not looking at the dashboard).
+        await self._pending_prompts.put((text, None, True))
+
+    def on_user_preempt(self) -> None:
+        if self._cancel_current_turn():
+            self.app.hide_thinking()
+            self.app.post_system_notice("(interrupted)", style="dim yellow")
+
+    async def on_exit_stop_runs(self) -> None:
+        """Second Ctrl-C — stop every active `weco run` before tearing down."""
+        run_ids = self._run_watcher.watching() if self._run_watcher is not None else []
+        if not run_ids:
+            return
+        weco_bin = shutil.which("weco")
+        if not weco_bin:
+            return
+        self.app.post_system_notice(f"Stopping {len(run_ids)} active run(s)…", style="dim yellow")
+        await asyncio.gather(*(self._stop_one_run(weco_bin, rid) for rid in run_ids), return_exceptions=True)
+
+    async def _stop_one_run(self, weco_bin: str, run_id: str) -> None:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                weco_bin, "run", "stop", run_id, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            )
+            await asyncio.wait_for(proc.wait(), timeout=RUN_STOP_TIMEOUT_S)
+        except Exception:
+            pass
+
+    def _on_sigint(self) -> None:
+        # First-press fallback path. The TUI's two-tier handler owns the
+        # primary UX; this only fires outside the TUI capture.
+        if not self._cancel_current_turn():
+            self._stop_event.set()
+            self.app.exit()
+
+    def _cancel_current_turn(self) -> bool:
+        """Interrupt the in-flight prompt-turn (if any). Returns True if one was
+        running and we kicked off an interrupt, False otherwise."""
+        if self._inflight_turns <= 0:
+            return False
+        if self._interrupting:
+            # Already draining a prior interrupt — let the in-flight SDK
+            # interrupt finish. Returning False lets the caller escalate.
+            return False
+        client = self._sdk_client
+        if client is not None:
+            # Send the SDK an interrupt control message; the single consumer
+            # drains the interrupted turn's tail in order — the SDK's synthetic
+            # `[Request interrupted]` user-message (skipped) and its terminal
+            # ResultMessage (swallowed in `_fan_out`, which also clears
+            # `_interrupting`). A queued follow-up prompt then submits cleanly:
+            # because one in-order consumer owns the stream, there's no stale
+            # buffered ResultMessage for a new receive loop to trip over.
+            self._interrupting = True
+            asyncio.create_task(_safe_interrupt(client))
+        # Tell consumers we're interrupting now — the user already moved on.
+        self._emit_meta("turn_interrupted")
+        self.app.hide_thinking()
+        # Tear down pending cards — the turn they gated on is gone.
+        self._dismiss_active_cards()
+        return True
+
+    def _dismiss_active_cards(self) -> None:
+        """Freeze every pending approval/question card. `resolve_remotely({})`
+        is a no-op on an already-answered card; ApprovalCard reads it as
+        deny-once."""
+        for cards in (self._active_approval_cards, self._active_question_cards):
+            for card in list(cards.values()):
+                try:
+                    card.resolve_remotely({})
+                except Exception:
+                    pass
+            cards.clear()
+
+    # --- Dashboard → bridge ---------------------------------------------
+
+    async def _handle_inbound(self, msg: str) -> None:
+        try:
+            event = json.loads(msg)
+        except Exception:
+            return
+        if not isinstance(event, dict):
+            return
+        handler = {
+            "inject_prompt": self._inbound_inject_prompt,
+            "approval_response": self._inbound_approval_response,
+            "question_response": self._inbound_question_response,
+            "interrupt": self._inbound_interrupt,
+            "derive_request": self._inbound_derive_request,
+        }.get(event.get("type"))
+        if handler is not None:
+            await handler(event)
+
+    async def _inbound_inject_prompt(self, event: dict) -> None:
+        text = event.get("text")
+        if not isinstance(text, str) or not text:
+            return
+        self._cancel_current_turn()
+        self.app.post_user_message(text)
+        # Dashboard-initiated actions (e.g. "Explore a new path" derives) list
+        # new runs as `Run ID: <uuid>` lines — watch them mechanically so
+        # terminal/dashboard pings don't depend on the agent acting.
+        if self._run_watcher is not None:
+            for run_id in find_run_ids(text):
+                self._run_watcher.watch(run_id)
+        # Optional `context` rides with the prompt — the dashboard bundles its
+        # current view snapshot so the agent has context for THIS turn without
+        # a continuous `ui_context` broadcast.
+        raw_ctx = event.get("context")
+        ctx = {k: v for k, v in raw_ctx.items() if k in UI_CONTEXT_KEYS} if isinstance(raw_ctx, dict) else None
+        await self._pending_prompts.put((text, ctx, True))
+
+    async def _inbound_derive_request(self, event: dict) -> None:
+        """Dashboard "Explore a new path" — a structured request to launch
+        derived runs. Surfaces as a `_weco_meta:derive_request` transcript card
+        (not a user chat bubble); the agent receives full launch instructions.
+        """
+        paths = parse_derive_paths(event)
+        run_id = event.get("run_id")
+        if not isinstance(run_id, str) or not run_id or not paths:
+            return
+        self._cancel_current_turn()
+        # Structured transcript card for the dashboard (+ scrollback replay).
+        self._emit_meta("derive_request", run_id=run_id, paths=paths)
+        noun = "path" if len(paths) == 1 else "paths"
+        self.app.post_system_notice(f"Dashboard derive request: {len(paths)} {noun} — launching…", style="dim cyan")
+        await self._pending_prompts.put((build_derive_prompt(run_id, paths), None, False))
+
+    async def _inbound_approval_response(self, event: dict) -> None:
+        request_id = event.get("id")
+        decision = event.get("decision")
+        scope = str(event.get("scope", "once"))
+        if not (isinstance(request_id, str) and decision in VALID_DECISIONS and self._approval_router is not None):
+            return
+        # If the local TUI also has a card for this id, tell it the answer
+        # landed on the dashboard so it stops awaiting. Do this *before*
+        # resolving the router so the card transitions cleanly even if the
+        # router resolution triggers a fast SDK callback.
+        card = self._active_approval_cards.pop(request_id, None)
+        if card is not None:
+            try:
+                card.resolve_remotely_decision(decision, scope)
+            except Exception:
+                pass
+        self._approval_router.resolve(request_id, decision, scope)
+
+    async def _inbound_question_response(self, event: dict) -> None:
+        request_id = event.get("id")
+        answers = event.get("answers")
+        if not (isinstance(request_id, str) and isinstance(answers, dict) and self._approval_router is not None):
+            return
+        card = self._active_question_cards.pop(request_id, None)
+        if card is not None:
+            try:
+                card.resolve_remotely(answers)
+            except Exception:
+                pass
+        self._approval_router.resolve_question(request_id, answers)
+
+    async def _inbound_interrupt(self, event: dict) -> None:
+        if self._cancel_current_turn():
+            self.app.hide_thinking()
+            self.app.post_system_notice("(interrupted from dashboard)", style="dim yellow")
+
+    # --- Approval router → local modal ----------------------------------
+    #
+    # An approval and an AskUserQuestion ride the same inline-picker component
+    # and the same cross-surface race: whichever surface (local TUI card or
+    # dashboard) answers first resolves the SDK call; the loser is de-duped.
+    # `_drive_inline_card` owns that shared lifecycle; the two `_on_*_request`
+    # entry points just supply the card, the fallback, and the wire shapes.
+
+    def _on_approval_request(self, request_id: str, tool_name: str, summary: str, tool_input: dict[str, Any]) -> None:
+        if request_id in self._approval_card_inflight:
+            return
+        self._approval_card_inflight.add(request_id)
+
+        async def task() -> None:
+            future: asyncio.Future = asyncio.get_running_loop().create_future()
+            await self._drive_inline_card(
+                request_id=request_id,
+                inflight=self._approval_card_inflight,
+                active=self._active_approval_cards,
+                card=ApprovalCard(tool_name, summary, future),
+                future=future,
+                fallback=("deny", "once"),
+                resolve_router=lambda result: self._approval_router.resolve(request_id, *result),
+                response_event="approval_response",
+                response_fields=lambda result: {"decision": result[0], "scope": result[1]},
+            )
+
+        asyncio.create_task(task())
+
+    def _on_question_request(self, request_id: str, questions: list[dict]) -> None:
+        if request_id in self._question_card_inflight:
+            return
+        self._question_card_inflight.add(request_id)
+
+        async def task() -> None:
+            future: asyncio.Future = asyncio.get_running_loop().create_future()
+            await self._drive_inline_card(
+                request_id=request_id,
+                inflight=self._question_card_inflight,
+                active=self._active_question_cards,
+                card=QuestionCard(questions, future),
+                future=future,
+                fallback={},
+                resolve_router=lambda result: self._approval_router.resolve_question(request_id, result),
+                response_event="question_response",
+                response_fields=lambda result: {"answers": result},
+            )
+
+        asyncio.create_task(task())
+
+    async def _drive_inline_card(
+        self,
+        *,
+        request_id: str,
+        inflight: set[str],
+        active: dict[str, Any],
+        card: Any,
+        future: asyncio.Future,
+        fallback: Any,
+        resolve_router: Callable[[Any], None],
+        response_event: str,
+        response_fields: Callable[[Any], dict],
+    ) -> None:
+        """Mount an inline picker, await an answer from any surface, then
+        resolve the SDK call and broadcast the answer to the dashboard."""
+        active[request_id] = card
+        try:
+            self.app.mount_inline_card(card)
+        except Exception:
+            # Mount failed → resolve with the fallback so the await below
+            # returns instead of hanging the SDK call on a card that never
+            # appeared.
+            if not future.done():
+                future.set_result(fallback)
+
+        try:
+            result = await future
+        except asyncio.CancelledError:
+            result = fallback
+        finally:
+            active.pop(request_id, None)
+            inflight.discard(request_id)
+
+        if self._approval_router is None:
+            return
+        # Resolve the SDK side first so claude can continue, then broadcast so
+        # the dashboard's card dismisses. If the dashboard answered first both
+        # are no-ops (router de-dupes; the dashboard already dropped its card).
+        resolve_router(result)
+        self._emit_meta(response_event, id=request_id, source="cli", **response_fields(result))
+
+    def _capture_sdk_stderr(self, line: str) -> None:
+        """Sink for the SDK subprocess's stderr. The TUI owns the terminal so
+        raw stderr is invisible; we keep the tail for the connect/run error
+        paths to flush into a system notice."""
+        if not isinstance(line, str):
+            return
+        self._sdk_stderr_buf.append(line)
+        if len(self._sdk_stderr_buf) > STDERR_BUFFER_LINES:
+            del self._sdk_stderr_buf[:-STDERR_BUFFER_LINES]
+
+    # --- Run watcher → app + dashboard ----------------------------------
+
+    def _notify_run_update(self, update: dict) -> None:
+        if not isinstance(update, dict):
+            return
+        # Both surfaces are best-effort and independently guarded: a failure
+        # publishing to the dashboard must not stop the local render, and a
+        # render error must not bubble out of the run-watcher's notify
+        # callback — that would kill the polling task and silently freeze
+        # *all* further updates (the watcher is shared across surfaces).
+        try:
+            self._emit_meta("run_update", **update)
+        except Exception:
+            pass
+        try:
+            self.app.post_run_update(update)
+        except Exception:
+            pass
+
+    # --- Stream consumer + prompt pump -----------------------------------
+
+    async def _consume_messages(self) -> None:
+        """Single long-lived consumer of the SDK message stream — the SDK's
+        blessed streaming pattern (one `receive_messages()` owner; prompts fed
+        via `query()` from `_prompt_pump`). Fans out EVERY message the instant
+        the SDK surfaces it, whether it belongs to a user-prompted turn or to a
+        between-turn autonomous one (background-task completions, scheduled
+        wakeups). The old per-turn `receive_response()` drained only while a
+        prompt was in flight, so messages produced between turns sat buffered in
+        the transport until the next prompt flushed them — appearing late, in a
+        burst, on both the TUI and dashboard at once."""
+        client = self._sdk_client
+        if client is None:
+            return
+        try:
+            async for message in client.receive_messages():
+                if self._stop_event.is_set():
+                    return
+                self._fan_out(message)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            # The receive stream died (transport/SDK error). Nothing can be
+            # consumed after this — surface it (unless we're already shutting
+            # down, where disconnect() ends the stream by design) and bring the
+            # session down so the prompt pump unblocks and `_shutdown` runs.
+            if not self._stop_event.is_set():
+                self.app.post_system_notice(f"Claude SDK error: {e}", style="bold red")
+                stderr_blob = "".join(self._sdk_stderr_buf).strip()
+                if stderr_blob:
+                    self.app.post_system_notice(f"claude stderr:\n{stderr_blob}", style="dim red")
+                self._emit_meta("claude_error", message=str(e), stderr=stderr_blob or None)
+        finally:
+            self._stop_event.set()
+
+    def _fan_out(self, message: Any) -> None:
+        """Render one SDK message to every surface — dashboard mirror, run
+        watcher, local TUI. Each side effect is independently guarded so one
+        failure can't abandon the consumer loop (which would strand every later
+        message). Also owns turn-boundary bookkeeping (`_inflight_turns`,
+        `_interrupting`), now that the boundary is observed in the stream rather
+        than by a per-turn receive loop ending."""
+        # While interrupting, the SDK emits a synthetic UserMessage
+        # ("[Request interrupted by user]") then a final ResultMessage. Drop the
+        # synthetic message; the ResultMessage is handled just below.
+        if is_synthetic_interrupt_message(message):
+            return
+        if isinstance(message, ResultMessage):
+            # Terminal message of a turn: settle the in-flight count, and if this
+            # closes an interrupted turn, swallow it — `turn_interrupted` already
+            # signalled the early end and its `error_during_execution` would read
+            # like a bug the user caused themselves.
+            self._inflight_turns = max(0, self._inflight_turns - 1)
+            if self._interrupting:
+                self._interrupting = False
+                return
+
+        try:
+            envelope = envelope_for(message)
+            if envelope is not None:
+                self._session.publish(json.dumps(envelope))
+        except Exception:
+            pass
+
+        try:
+            if self._run_watcher is not None:
+                scan_for_run_ids(message, self._run_watcher)
+        except Exception:
+            pass
+
+        try:
+            self._renderer.render(message)
+        except Exception:
+            # Don't let a render bug derail the session.
+            pass
+
+    async def _prompt_pump(self) -> None:
+        """Feed queued prompts into the SDK. Response *consumption* is owned by
+        `_consume_messages`; this only submits query()s. Returns when the session
+        is stopping."""
+        while not self._stop_event.is_set():
+            entry = await self._next_prompt()
+            if entry is None:
+                return
+            await self._submit_prompt(entry)
+
+    async def _next_prompt(self) -> Optional[tuple[str, Optional[dict], bool]]:
+        stop_task = asyncio.create_task(self._stop_event.wait())
+        get_task = asyncio.create_task(self._pending_prompts.get())
+        done, _ = await asyncio.wait({stop_task, get_task}, return_when=asyncio.FIRST_COMPLETED)
+        if get_task in done:
+            stop_task.cancel()
+            return get_task.result()
+        get_task.cancel()
+        return None
+
+    async def _submit_prompt(self, prompt_entry: tuple[str, Optional[dict], bool]) -> None:
+        prompt, ctx, echo_user = prompt_entry
+        client = self._sdk_client
+        if client is None:
+            return
+
+        # Mirror the user's prompt to the dashboard transcript first so both
+        # surfaces see it before the agent starts thinking. Structured requests
+        # (echo_user=False) already surfaced as their own meta card.
+        if echo_user:
+            self._session.publish(json.dumps({"type": "user", "message": {"role": "user", "content": prompt}}))
+
+        # A dashboard prompt may carry a UI-view snapshot; prepend it as a
+        # hidden system reminder so the agent can answer "what am I looking
+        # at?" without the user spelling it out. TUI prompts carry ctx=None.
+        outgoing = render_ui_context_preamble(ctx) + prompt
+
+        self.app.show_thinking()
+        # Count the turn in flight BEFORE query() returns, so a fast first
+        # message can never decrement past it. The consumer settles it on the
+        # turn's ResultMessage.
+        self._inflight_turns += 1
+        try:
+            await client.query(outgoing)
+        except Exception as e:
+            self._inflight_turns = max(0, self._inflight_turns - 1)
+            self.app.hide_thinking()
+            self.app.post_system_notice(f"Claude SDK error: {e}", style="bold red")
+            stderr_blob = "".join(self._sdk_stderr_buf).strip()
+            if stderr_blob:
+                self.app.post_system_notice(f"claude stderr:\n{stderr_blob}", style="dim red")
+            self._emit_meta("claude_error", message=str(e), stderr=stderr_blob or None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _safe_interrupt(client: ClaudeSDKClient) -> None:
+    try:
+        await client.interrupt()
+    except Exception:
+        pass
+
+
+def parse_derive_paths(event: dict) -> list[dict]:
+    """Validate a derive_request's `paths` into `{node_id, step?, instructions?, steps?}` dicts."""
+    raw = event.get("paths")
+    if not isinstance(raw, list):
+        return []
+    paths: list[dict] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        node_id = item.get("node_id")
+        if not isinstance(node_id, str) or not node_id:
+            continue
+        path: dict = {"node_id": node_id}
+        if isinstance(item.get("step"), (int, float)):
+            path["step"] = item["step"]
+        instructions = item.get("instructions")
+        if isinstance(instructions, str) and instructions.strip():
+            path["instructions"] = instructions.strip()
+        # Per-path step-count override (`weco run derive -n`); inherit when absent.
+        steps = item.get("steps")
+        if isinstance(steps, int) and not isinstance(steps, bool) and steps >= 1:
+            path["steps"] = steps
+        paths.append(path)
+    return paths
+
+
+def build_derive_prompt(run_id: str, paths: list[dict]) -> str:
+    """Agent instructions for a dashboard derive request.
+
+    One `weco run derive` per path: the first command becomes the lineage's
+    evaluation consumer (working-tree lock); the rest attach and queue behind
+    it — so this works whether or not a weco process is already running.
+    """
+    commands = []
+    for path in paths:
+        cmd = f"weco run derive {run_id} --from-step {path['node_id']}"
+        instructions = path.get("instructions")
+        if instructions:
+            cmd += f" -i {shlex.quote(instructions)}"
+        steps = path.get("steps")
+        if steps:
+            cmd += f" -n {steps}"
+        cmd += " --output plain"
+        commands.append(cmd)
+    return (
+        f"[Dashboard derive request] The user composed {len(paths)} derived run(s) from run {run_id} "
+        f'in the dashboard ("Explore a new path"). Launch each command below now, each as a background '
+        f"task (run_in_background: true) — the first becomes the evaluation consumer for the lineage and "
+        f"the rest attach behind it, so do not wait for one to finish before starting the next:\n\n"
+        + "\n".join(commands)
+        + "\n\nThen briefly confirm, report the new run IDs, and add them ALL to your monitoring loop "
+        "(poll `weco run status <run-id>` for each, non-blocking; report new bests and completions)."
+    )
+
+
+def scan_for_run_ids(message: Any, run_watcher: RunWatcher) -> None:
+    """Spot `Run ID: <uuid>` in tool_result text and start polling.
+
+    The run watcher's notify callback surfaces status updates to the UI via
+    `Orchestrator._notify_run_update`, so no app reference is needed here.
+    """
+    if not isinstance(message, UserMessage):
+        return
+    blocks = message.content if isinstance(message.content, list) else []
+    for block in blocks:
+        if isinstance(block, ToolResultBlock):
+            text = stringify_tool_result(block.content)
+            if text:
+                for run_id in find_run_ids(text):
+                    run_watcher.watch(run_id)

--- a/weco/consumer_lock.py
+++ b/weco/consumer_lock.py
@@ -1,0 +1,88 @@
+"""A per-working-tree lock guaranteeing a single evaluation consumer.
+
+The optimization loop evaluates candidates by swapping their code into the
+working directory, running the eval command, then restoring the originals
+(``run_evaluation_with_files_swap``). Two consumers doing that concurrently in
+the same tree clobber each other's files mid-eval. With parallel derived runs
+feeding one lineage queue, the invariant we need is: **at most one consumer per
+working tree.**
+
+This module enforces it with an advisory ``flock`` on ``.weco/consumer.lock``
+in the working directory. Acquisition is non-blocking (try-lock): a second
+consumer that finds the lock held does *not* start a competing loop — it leaves
+the work to the consumer already draining the lineage.
+
+POSIX only. On platforms without ``fcntl`` the lock is a best-effort no-op
+(``acquired=True``) — parallel derive there falls back to today's behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+try:
+    import fcntl  # POSIX
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+# Sentinel handle returned when advisory locking is unavailable (non-POSIX):
+# we report "acquired" so behavior falls back to today's, but hold no real lock.
+_NOOP_HANDLE = -1
+
+
+def _lock_path(workdir: Optional[str]) -> pathlib.Path:
+    base = pathlib.Path(workdir) if workdir else pathlib.Path.cwd()
+    return base / ".weco" / "consumer.lock"
+
+
+def try_acquire(workdir: Optional[str] = None) -> Optional[int]:
+    """Non-blocking acquire of the working-tree consumer lock.
+
+    Returns an opaque handle if this process now holds the lock, or ``None`` if
+    another consumer already holds it. Pass the handle to :func:`release`. On
+    platforms without ``fcntl`` this always "succeeds" (best-effort no-op).
+    """
+    if fcntl is None:
+        return _NOOP_HANDLE
+    path = _lock_path(workdir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        os.close(fd)
+        return None
+    return fd
+
+
+def release(handle: Optional[int]) -> None:
+    """Release a lock handle returned by :func:`try_acquire`. Safe on None."""
+    if handle is None or handle == _NOOP_HANDLE or fcntl is None:
+        return
+    try:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(handle)
+        except OSError:
+            pass
+
+
+@contextmanager
+def consumer_lock(workdir: Optional[str] = None) -> Iterator[bool]:
+    """Context-manager form of :func:`try_acquire`.
+
+    Yields ``True`` if this process now holds the lock (and should consume), or
+    ``False`` if another consumer already holds it. Released on exit. Never blocks.
+    """
+    handle = try_acquire(workdir)
+    try:
+        yield handle is not None
+    finally:
+        release(handle)

--- a/weco/core/api.py
+++ b/weco/core/api.py
@@ -135,6 +135,10 @@ class ExecutionTasksResult:
 
     tasks: list
     run: Optional[RunSummary] = None
+    # Lineage mode only: number of runs in the lineage still active
+    # (running/stopping). Meaningful when ``tasks`` is empty; lets the lineage
+    # consumer decide wait-vs-done from a single read. None in run_id mode.
+    active_run_count: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +171,34 @@ class WecoClient:
 
     def _put(self, path: str, *, timeout=(5, 10)) -> requests.Response:
         return self._session.put(self._url(path), timeout=timeout)
+
+    def _patch(self, path: str, *, json: dict | None = None, timeout=(5, 10)) -> requests.Response:
+        return self._session.patch(self._url(path), json=json, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Dashboard sessions (`weco start` agent bridges)
+    # ------------------------------------------------------------------
+
+    def create_session(self, agent_type: str) -> dict:
+        """Create a dashboard session and return its Realtime credentials:
+        ``{session, dashboard_url, realtime}``. Raises on HTTP/network error."""
+        resp = self._post("/sessions", json={"agent_type": agent_type}, timeout=(5, 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def refresh_realtime_token(self, session_id: str) -> dict:
+        """Mint a fresh Realtime JWT for an existing session."""
+        resp = self._post(f"/sessions/{session_id}/realtime-token", timeout=(5, 30))
+        resp.raise_for_status()
+        return resp.json()
+
+    def session_heartbeat(self, session_id: str) -> None:
+        """Roll the session's `expires_at` forward. Best-effort — caller swallows."""
+        self._post(f"/sessions/{session_id}/heartbeat", timeout=(5, 10))
+
+    def close_session(self, session_id: str) -> None:
+        """Mark the session closed so the dashboard updates without waiting for TTL."""
+        self._patch(f"/sessions/{session_id}", json={"status": "closed"}, timeout=(5, 10))
 
     # ------------------------------------------------------------------
     # Runs
@@ -505,6 +537,35 @@ class WecoClient:
             return ExecutionTasksResult(tasks=data.get("tasks", []), run=run_summary)
         except Exception:
             return None
+
+    def get_lineage_execution_tasks(self, lineage_id: str) -> ExecutionTasksResult | None:
+        """``GET /execution-tasks/?lineage_id=`` — poll for ready tasks across an
+        entire lineage. Used by the single lineage consumer that serializes evals
+        over parallel derived runs. Top-level ``run`` is None in this mode; each
+        task carries its own ``run`` summary (read as ``task["run"]``)."""
+        try:
+            resp = self._get("/execution-tasks/", params={"lineage_id": lineage_id}, timeout=(5, 30))
+            resp.raise_for_status()
+            data = resp.json()
+            return ExecutionTasksResult(tasks=data.get("tasks", []), run=None, active_run_count=data.get("active_run_count"))
+        except Exception:
+            return None
+
+    def heartbeat_lineage(self, lineage_id: str) -> bool:
+        """``POST /lineages/{lineage_id}/heartbeat`` — keep every running member
+        of the lineage alive in one call. One live consumer owns the lineage and
+        serializes its evals; members awaiting their turn must not be reaped."""
+        try:
+            resp = self._post(f"/lineages/{lineage_id}/heartbeat", timeout=(5, 10))
+            resp.raise_for_status()
+            return True
+        except requests.exceptions.HTTPError as e:
+            code = getattr(e.response, "status_code", None)
+            print(f"Lineage heartbeat failed for {lineage_id}: HTTP {code}", file=sys.stderr)
+            return False
+        except Exception as e:
+            print(f"Error sending lineage heartbeat for {lineage_id}: {e}", file=sys.stderr)
+            return False
 
     def claim_task(self, task_id: str) -> dict | None:
         """``POST /execution-tasks/{task_id}/claim`` — claim a task for evaluation."""

--- a/weco/env.py
+++ b/weco/env.py
@@ -16,6 +16,7 @@ Usage::
 """
 
 import pathlib
+import sys
 import time
 from dataclasses import dataclass
 
@@ -174,6 +175,14 @@ class WecoEnv:
 
 
 def _print_update_warning(message: str) -> None:
-    """Print a yellow warning and pause briefly so the user sees it."""
-    print(f"\033[93m{message}\033[0m")
+    """Print a yellow warning and pause briefly so the user sees it.
+
+    Suppressed when stdout isn't a TTY — that means the caller is piping or
+    capturing our output (e.g. the wrapper's RunWatcher polling
+    ``weco run status <id>``). In that case the banner would pollute stdout
+    JSON and the 2-second sleep would slow down every poll.
+    """
+    if not sys.stdout.isatty():
+        return
+    print(f"\033[93m{message}\033[0m", file=sys.stderr)
     time.sleep(2)

--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -6,6 +6,7 @@ import threading
 import time
 import traceback
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, Optional
 
 from requests.exceptions import ConnectionError as RequestsConnectionError, HTTPError, ReadTimeout
@@ -17,20 +18,41 @@ from .api import (
     claim_execution_task,
     format_api_error,
     get_execution_tasks,
+    get_lineage_execution_tasks,
     get_optimization_run_status,
     report_termination,
     resume_optimization_run,
     send_heartbeat,
+    send_lineage_heartbeat,
     start_optimization_run,
     submit_execution_result,
 )
 from .core.api import WecoClient
 from .artifacts import RunArtifacts
+from .consumer_lock import try_acquire, release
 from .auth import handle_authentication
 from .events import get_event_context
 from .browser import open_browser
 from .ui import OptimizationUI, LiveOptimizationUI, PlainOptimizationUI
 from .utils import read_additional_instructions, read_from_path, write_to_path, run_evaluation_with_files_swap
+
+
+def _should_auto_open_browser(no_open: bool) -> bool:
+    """Whether the CLI should pop the run's dashboard URL in a new tab.
+
+    Suppressed when:
+      * `--no-open` was passed explicitly, or
+      * the CLI is running inside a `weco start <agent>` session (signalled
+        by `WECO_CC_SESSION_ID` in the env). In that case the attached
+        dashboard receives the new run via the session's Realtime channel
+        and surfaces it with an in-page toast instead — popping a separate
+        tab on top of an already-open dashboard would be noise.
+    """
+    if no_open:
+        return False
+    if os.environ.get("WECO_CC_SESSION_ID"):
+        return False
+    return True
 
 
 @dataclass
@@ -64,6 +86,36 @@ _TRANSIENT_REASONS = frozenset({"transient_network_error", "http_502", "http_503
 
 def _is_transient(result: OptimizationResult) -> bool:
     return result.reason in _TRANSIENT_REASONS
+
+
+class _PollAction(Enum):
+    """What a single lineage-queue poll tells the consumer to do next."""
+
+    PROCESS = "process"  # ready work exists — claim and evaluate it
+    WAIT = "wait"  # uncertain, or runs active but no ready task — keep polling
+    DONE = "done"  # confirmed: read succeeded, no ready work, no active runs
+
+
+def _classify_lineage_poll(read_ok: bool, has_ready: bool, active_run_count: Optional[int]) -> _PollAction:
+    """Decide what one lineage-queue poll means. Pure — no I/O, no state.
+
+    The single rule that prevents orphaning: only a *confirmed* read showing no
+    ready work AND no active runs is ``DONE``. A failed read, or an active run
+    with no ready task yet (between candidates, or freshly derived), is ``WAIT``
+    — never mistaken for "the lineage is finished".
+
+    ``active_run_count`` is authoritative only when ``has_ready`` is False (the
+    backend omits it when tasks are present, since the consumer processes those
+    regardless). ``None`` there means the backend didn't report it (e.g. version
+    skew) — treated as ``WAIT`` rather than guessing ``DONE``.
+    """
+    if not read_ok:
+        return _PollAction.WAIT
+    if has_ready:
+        return _PollAction.PROCESS
+    if active_run_count is None or active_run_count > 0:
+        return _PollAction.WAIT
+    return _PollAction.DONE
 
 
 def _silent_resume(run_id: str, auth_headers: dict, api_keys: Optional[dict]) -> bool:
@@ -149,6 +201,34 @@ class HeartbeatSender(threading.Thread):
         except Exception as e:
             # Avoid silent heartbeat thread failures during long runs.
             print(f"[ERROR HeartbeatSender] Unexpected error in heartbeat thread for run {self.run_id}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+
+
+class LineageHeartbeatSender(threading.Thread):
+    """Heartbeat every ``running`` member of a lineage on a fixed cadence.
+
+    One call (``POST /lineages/{id}/heartbeat``) keeps all running members alive
+    — including derived runs queued behind the one currently being evaluated.
+    The single lineage consumer owns liveness for the whole lineage, so a member
+    waiting its turn isn't reaped by the heartbeat-timeout cron.
+    """
+
+    def __init__(self, lineage_id: str, auth_headers: dict, stop_event: threading.Event, interval: int = 30):
+        super().__init__(daemon=True)
+        self.lineage_id = lineage_id
+        self.auth_headers = auth_headers
+        self.interval = interval
+        self.stop_event = stop_event
+
+    def run(self):
+        try:
+            while not self.stop_event.is_set():
+                send_lineage_heartbeat(self.lineage_id, self.auth_headers)
+                if self.stop_event.is_set():
+                    break
+                self.stop_event.wait(self.interval)
+        except Exception as e:
+            print(f"[ERROR LineageHeartbeatSender] Unexpected error for lineage {self.lineage_id}: {e}", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
 
 
@@ -330,6 +410,246 @@ def run_optimization_loop(
         return OptimizationResult(success=False, final_step=step, status="error", reason="unknown", details=str(e))
 
 
+class _TaggedPlainUI(PlainOptimizationUI):
+    """Plain UI whose every line is prefixed with the run name, so a single
+    lineage consumer's interleaved per-run output stays readable."""
+
+    def _print(self, message: str) -> None:
+        print(f"[{self.run_name}] {message}", flush=True)
+
+
+def _build_run_state(run_id: str, auth_headers: dict, log_dir: str, dashboard_base: str) -> dict:
+    """Lazily construct per-run UI + artifacts for a run discovered in the queue.
+
+    Eval config (command/timeout/save_logs) is lineage-invariant and supplied to
+    the loop once; here we only fetch the per-run *display* fields (name, model,
+    step target, metric) for the run's UI header.
+    """
+    run_name = run_id
+    metric_name = "metric"
+    maximize = True
+    total_steps = 0
+    model = ""
+    current_step = 0
+    lineage_id = run_id
+    try:
+        status = get_optimization_run_status(console=None, run_id=run_id, include_history=False, auth_headers=auth_headers)
+        run_name = status.get("run_name", run_id)
+        objective = status.get("objective", {}) or {}
+        metric_name = objective.get("metric_name", "metric")
+        maximize = bool(objective.get("maximize", True))
+        optimizer = status.get("optimizer", {}) or {}
+        total_steps = optimizer.get("steps", 0) or 0
+        model = (optimizer.get("code_generator") or {}).get("model") or ""
+        current_step = int(status.get("current_step", 0) or 0)
+        lineage_id = status.get("lineage_id") or run_id
+    except Exception:
+        pass  # Display-only; fall back to ids if status is unavailable.
+
+    ui = _TaggedPlainUI(
+        run_id,
+        run_name,
+        total_steps,
+        f"{dashboard_base}/runs/{lineage_id}",
+        model=model,
+        metric_name=metric_name,
+        maximize=maximize,
+    )
+    ui.on_init()
+    return {"ui": ui, "artifacts": RunArtifacts(log_dir=log_dir, run_id=run_id), "step": max(current_step, 1), "done": False}
+
+
+def run_lineage_loop(
+    lineage_id: str,
+    auth_headers: dict,
+    originals: dict[str, str],
+    eval_command: str,
+    eval_timeout: Optional[int],
+    save_logs: bool,
+    log_dir: str,
+    dashboard_base: str,
+    *,
+    api_keys: Optional[dict] = None,
+    submit_timeout: Optional[int] = None,
+    poll_interval: float = 2.0,
+    max_idle_polls: int = 300,
+) -> bool:
+    """Single consumer that drains every active run in a lineage, one eval at a time.
+
+    The collision-safe generalization of :func:`run_optimization_loop`: instead of
+    one run, it polls the lineage-wide ready queue, claims one task at a time,
+    evaluates it via the shared working tree (serially — never two at once), and
+    submits. It keeps every running member alive with a single lineage heartbeat,
+    and exits only when no member is running and the queue is empty.
+
+    The caller MUST hold the working-tree consumer lock for the duration. Eval
+    config (``eval_command``/``eval_timeout``/``save_logs``/``originals``) is
+    lineage-invariant; only per-run display state is fetched lazily.
+
+    Returns ``True`` unless an account-level failure (auth / insufficient credits)
+    aborted the consumer.
+    """
+    states: dict[str, dict] = {}
+    fatal = False
+    # Consecutive non-PROCESS polls since work last flowed. Bounds the wait when
+    # the backend is wedged (active runs that never produce a task) or the queue
+    # read keeps failing — the only ways the loop can spin without progress.
+    idle_polls = 0
+
+    stop_event = threading.Event()
+    heartbeat_thread = LineageHeartbeatSender(lineage_id, auth_headers, stop_event)
+    heartbeat_thread.start()
+
+    print(f"[lineage {lineage_id}] consumer started; draining ready evaluations across the lineage.", flush=True)
+
+    try:
+        while True:
+            # One authoritative read per poll: ready tasks across the lineage,
+            # plus active_run_count (how many members are still running/stopping)
+            # when the queue is empty. _classify_lineage_poll turns it into an
+            # action — never declaring "done" on an unconfirmed read.
+            tasks_result = get_lineage_execution_tasks(lineage_id, auth_headers)
+            read_ok = tasks_result is not None  # None == read failed, NOT "empty"
+            ready = (tasks_result.tasks if tasks_result else []) or []
+            active_run_count = tasks_result.active_run_count if tasks_result else None
+
+            action = _classify_lineage_poll(read_ok, bool(ready), active_run_count)
+
+            if action is _PollAction.DONE:
+                break
+            if action is _PollAction.WAIT:
+                idle_polls += 1
+                if idle_polls >= max_idle_polls:
+                    print(f"[lineage {lineage_id}] no progress after {max_idle_polls} polls; stopping consumer.", flush=True)
+                    break
+                time.sleep(poll_interval)
+                continue
+            idle_polls = 0
+
+            task = ready[0]
+            run_id = task["run_id"]
+            task_run = task.get("run") or {}
+            if task_run.get("status") not in (None, "running"):
+                # Stale task for a run that's winding down; let the backend settle it.
+                time.sleep(poll_interval)
+                continue
+
+            st = states.get(run_id) or states.setdefault(
+                run_id, _build_run_state(run_id, auth_headers, log_dir, dashboard_base)
+            )
+            ui = st["ui"]
+            artifacts = st["artifacts"]
+            step = st["step"]
+
+            claimed = claim_execution_task(task["id"], auth_headers)
+            if claimed is None:
+                # No competing consumer should exist (we hold the lock); the task
+                # was likely cancelled as its run wound down. Skip it.
+                continue
+
+            code = claimed["revision"]["code"]
+            plan = claimed["revision"].get("plan")
+            ui.on_executing(step)
+            ui.on_task_claimed(task["id"], plan)
+
+            artifacts.save_step_code(step, code)
+            term_out = run_evaluation_with_files_swap(
+                file_map=code, originals=originals, eval_command=eval_command, timeout=eval_timeout
+            )
+            if save_logs:
+                artifacts.save_execution_output(step=step, output=term_out)
+            ui.on_output(term_out)
+
+            ui.on_submitting()
+            submit_timeout_tuple = (10, submit_timeout) if submit_timeout is not None else None
+            try:
+                result = submit_execution_result(
+                    run_id=run_id,
+                    task_id=task["id"],
+                    execution_output=term_out,
+                    auth_headers=auth_headers,
+                    api_keys=api_keys,
+                    timeout=submit_timeout_tuple,
+                )
+            except HTTPError as e:
+                msg = format_api_error(e)
+                ui.on_error(msg)
+                status_code = getattr(e.response, "status_code", None)
+                if status_code in (401, 402):
+                    # Account-level (auth / insufficient credits): affects every
+                    # member — stop the whole consumer.
+                    fatal = True
+                    break
+                # Per-run failure (e.g. 409: the run was finalized under us while
+                # winding down). Retire this run and keep draining the others.
+                st["done"] = True
+                st["step"] = step + 1
+                continue
+            except (RequestsConnectionError, ReadTimeout) as e:
+                ui.on_warning(f"Network error during evaluation submit: {e}")
+                time.sleep(poll_interval)
+                continue
+
+            is_done = result.get("is_done", False)
+            prev_metric = result.get("previous_solution_metric_value")
+            if prev_metric is not None:
+                ui.on_metric(step, prev_metric)
+            st["step"] = step + 1
+            if is_done:
+                ui.on_complete(st["step"])
+                st["done"] = True
+
+    except KeyboardInterrupt:
+        for st in states.values():
+            st["ui"].on_interrupted()
+    finally:
+        stop_event.set()
+        heartbeat_thread.join(timeout=2)
+
+    print(f"[lineage {lineage_id}] consumer finished.", flush=True)
+    return not fatal
+
+
+def _drain_lineage_remainder(
+    lineage_id: str,
+    auth_headers: dict,
+    originals: dict[str, str],
+    eval_command: str,
+    eval_timeout: Optional[int],
+    save_logs: bool,
+    log_dir: str,
+    *,
+    api_keys: Optional[dict] = None,
+    submit_timeout: Optional[int] = None,
+) -> None:
+    """After a single-run loop ends, drain any still-active siblings in its lineage.
+
+    Covers the case where runs were derived from this one while it was running:
+    the seed run's loop exits (completed, or stopped by the derive), and this
+    same process — still holding the working-tree consumer lock — keeps
+    evaluating the rest of the lineage. No-op when the lineage is quiet.
+    """
+    # One probe of the lineage queue: skip the drain only when we're certain the
+    # lineage is quiescent (read succeeded, no ready work, no active runs).
+    probe = get_lineage_execution_tasks(lineage_id, auth_headers)
+    has_ready = bool(probe.tasks) if probe else False
+    active_run_count = probe.active_run_count if probe else None
+    if _classify_lineage_poll(probe is not None, has_ready, active_run_count) is _PollAction.DONE:
+        return
+    run_lineage_loop(
+        lineage_id=lineage_id,
+        auth_headers=auth_headers,
+        originals=originals,
+        eval_command=eval_command,
+        eval_timeout=eval_timeout,
+        save_logs=save_logs,
+        log_dir=log_dir,
+        dashboard_base=__dashboard_url__,
+        api_keys=api_keys,
+        submit_timeout=submit_timeout,
+    )
+
+
 def offer_apply_best_solution(
     console: Console,
     run_id: str,
@@ -399,6 +719,67 @@ def offer_apply_best_solution(
         console.print(f"[yellow]Could not fetch best solution: {e}[/]")
 
 
+def _daemonize_to_log(run_id: str) -> Optional[pathlib.Path]:
+    """Fork + setsid + redirect FDs so the eval loop survives our agent's process tree.
+
+    POSIX-only. On platforms without ``os.fork`` (Windows), returns ``None`` and the
+    caller falls through to foreground execution. On success, the parent process
+    exits via ``os._exit(0)`` (skipping atexit handlers so it doesn't disturb global
+    state) — only the child returns from this function. The child's stdin is closed,
+    stdout/stderr are redirected to ``/tmp/weco-run-<run-id>.log``.
+
+    Call AFTER the create-run/auth POSTs (so the parent has a run_id to print) and
+    BEFORE starting any threads or async loops (which can't be safely forked).
+    """
+    if not hasattr(os, "fork"):
+        return None
+
+    log_path = pathlib.Path(f"/tmp/weco-run-{run_id}.log")
+
+    # Flush before fork so buffered output isn't duplicated by both processes.
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+    try:
+        pid = os.fork()
+    except OSError:
+        return None
+
+    if pid > 0:
+        # Parent: exit immediately, skipping Python finalizers. The child carries on.
+        os._exit(0)
+
+    # --- Child only past this point ---
+
+    # Detach from controlling terminal: become session + process-group leader.
+    try:
+        os.setsid()
+    except OSError:
+        pass
+
+    # Replace stdin with /dev/null so any blocking reads return EOF.
+    try:
+        devnull_fd = os.open(os.devnull, os.O_RDONLY)
+        os.dup2(devnull_fd, sys.stdin.fileno())
+        os.close(devnull_fd)
+    except OSError:
+        pass
+
+    # Redirect stdout/stderr to the log file. Anyone tailing it sees the full eval log.
+    try:
+        log_fd = os.open(str(log_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        os.dup2(log_fd, sys.stdout.fileno())
+        os.dup2(log_fd, sys.stderr.fileno())
+        os.close(log_fd)
+    except OSError:
+        pass
+
+    return log_path
+
+
 def resume_optimization(
     run_id: str,
     api_keys: Optional[dict] = None,
@@ -408,6 +789,8 @@ def resume_optimization(
     submit_timeout: Optional[int] = None,
     auto_resume_policy: Optional[AutoResumePolicy] = None,
     additional_steps: Optional[int] = None,
+    daemon: bool = False,
+    no_open: bool = False,
 ) -> bool:
     """
     Resume an interrupted or completed run using the queue-based optimization loop.
@@ -526,15 +909,45 @@ def resume_optimization(
     dashboard_url = f"{__dashboard_url__}/runs/{run_id}"
     run_name = resume_resp.get("run_name", run_id)
 
-    # Open dashboard in the user's browser
-    open_browser(dashboard_url)
+    if daemon:
+        # Print everything stdout-watchers (claude, cursor, the wrapper's find_run_ids)
+        # care about BEFORE forking — once we're detached, stdout is the log file.
+        print(f"Run ID: {run_id}", flush=True)
+        print(f"Run name: {run_name}", flush=True)
+        print(f"Dashboard: {dashboard_url}", flush=True)
+        log_path = _daemonize_to_log(run_id)
+        if log_path is None:
+            console.print("[yellow]--daemon not supported on this platform; running in foreground.[/]")
+        else:
+            # Force plain UI in the daemonized child — Rich's ANSI escapes
+            # would pollute the log file and serve no purpose without a TTY.
+            output_mode = "plain"
+            console = Console(force_terminal=False)
+            print(f"weco resume daemon started; log: {log_path}", flush=True)
+    elif _should_auto_open_browser(no_open):
+        open_browser(dashboard_url)
 
     # Setup artifacts manager
     artifacts = RunArtifacts(log_dir=log_dir, run_id=run_id)
 
-    # Start heartbeat thread
+    # Acquire the working-tree consumer lock so no derive starts a competing
+    # evaluation loop in this directory while we run. Released on the way out.
+    lock_handle = try_acquire()
+    if lock_handle is None:
+        console.print(
+            "[yellow]Another Weco optimization is already evaluating in this directory; "
+            "not starting a second consumer here.[/]"
+        )
+        return False
+
+    lineage_id = status.get("lineage_id") or run_id
+
+    # Start heartbeat thread. Heartbeat the whole lineage (not just this run) so
+    # that a run derived from this one mid-flight stays alive until our loop
+    # exits and we drain it — for a lone run, lineage_id == run_id, so this is
+    # identical to a single-run heartbeat.
     stop_heartbeat_event = threading.Event()
-    heartbeat_thread = HeartbeatSender(run_id, auth_headers, stop_heartbeat_event)
+    heartbeat_thread = LineageHeartbeatSender(lineage_id, auth_headers, stop_heartbeat_event)
     heartbeat_thread.start()
 
     # Extract best solution info from resume response (if available)
@@ -596,6 +1009,20 @@ def resume_optimization(
         stop_heartbeat_event.set()
         heartbeat_thread.join(timeout=2)
 
+        # Drain any runs derived from this one while it was running (still under
+        # the consumer lock). No-op when the lineage is quiet.
+        _drain_lineage_remainder(
+            lineage_id,
+            auth_headers,
+            source_code,
+            eval_command,
+            eval_timeout,
+            save_logs,
+            log_dir,
+            api_keys=api_keys,
+            submit_timeout=submit_timeout,
+        )
+
         # Show resume message if interrupted
         if result.status == "terminated":
             if output_mode == "plain":
@@ -613,11 +1040,16 @@ def resume_optimization(
             apply_change=apply_change,
         )
 
+        release(lock_handle)
         return result.success
     finally:
         # Ensure heartbeat is stopped (in case of early exit/exception)
         stop_heartbeat_event.set()
         heartbeat_thread.join(timeout=2)
+
+        # Release the working-tree consumer lock (idempotent if already released
+        # on the success path; OS would also release it on process exit).
+        release(lock_handle)
 
         # Report termination to backend
         if result is not None:
@@ -651,6 +1083,8 @@ def optimize(
     output_mode: str = "rich",
     submit_timeout: Optional[int] = None,
     auto_resume_policy: Optional[AutoResumePolicy] = None,
+    daemon: bool = False,
+    no_open: bool = False,
 ) -> bool:
     """
     Simplified queue-based optimization loop.
@@ -743,15 +1177,47 @@ def optimize(
     run_name = run_response["run_name"]
     dashboard_url = f"{__dashboard_url__}/runs/{run_id}"
 
-    # Open dashboard in the user's browser
-    open_browser(dashboard_url)
+    if daemon:
+        # Print everything stdout-watchers (claude, cursor, the wrapper's find_run_ids)
+        # care about BEFORE forking — once we're detached, stdout is the log file.
+        print(f"Run ID: {run_id}", flush=True)
+        print(f"Run name: {run_name}", flush=True)
+        print(f"Dashboard: {dashboard_url}", flush=True)
+        log_path = _daemonize_to_log(run_id)
+        if log_path is None:
+            console.print("[yellow]--daemon not supported on this platform; running in foreground.[/]")
+        else:
+            # Force plain UI in the daemonized child — Rich's ANSI escapes
+            # would pollute the log file and serve no purpose without a TTY.
+            output_mode = "plain"
+            console = Console(force_terminal=False)
+            print(f"weco run daemon started; log: {log_path}", flush=True)
+    elif _should_auto_open_browser(no_open):
+        open_browser(dashboard_url)
 
     # Setup artifacts manager
     artifacts = RunArtifacts(log_dir=log_dir, run_id=run_id)
 
-    # Start heartbeat thread
+    # Acquire the working-tree consumer lock so no derive starts a competing
+    # evaluation loop in this directory while we run. Released on the way out.
+    lock_handle = try_acquire()
+    if lock_handle is None:
+        console.print(
+            "[yellow]Another Weco optimization is already evaluating in this directory; "
+            "not starting a second consumer here.[/]"
+        )
+        return False
+
+    # A fresh run is its own lineage (lineage_id == run_id); runs derived from it
+    # while it runs share this id and are drained by this same process on exit.
+    lineage_id = run_id
+
+    # Start heartbeat thread. Heartbeat the whole lineage (not just this run) so
+    # that a run derived from this one mid-flight stays alive until our loop
+    # exits and we drain it — for a lone run, lineage_id == run_id, so this is
+    # identical to a single-run heartbeat.
     stop_heartbeat_event = threading.Event()
-    heartbeat_thread = HeartbeatSender(run_id, auth_headers, stop_heartbeat_event)
+    heartbeat_thread = LineageHeartbeatSender(lineage_id, auth_headers, stop_heartbeat_event)
     heartbeat_thread.start()
 
     result: Optional[OptimizationResult] = None
@@ -799,6 +1265,20 @@ def optimize(
         stop_heartbeat_event.set()
         heartbeat_thread.join(timeout=2)
 
+        # Drain any runs derived from this one while it was running (still under
+        # the consumer lock). No-op when the lineage is quiet.
+        _drain_lineage_remainder(
+            lineage_id,
+            auth_headers,
+            source_code,
+            eval_command,
+            eval_timeout,
+            save_logs,
+            log_dir,
+            api_keys=api_keys,
+            submit_timeout=submit_timeout,
+        )
+
         # Show resume message if interrupted
         if result.status == "terminated":
             if output_mode == "plain":
@@ -816,11 +1296,16 @@ def optimize(
             apply_change=apply_change,
         )
 
+        release(lock_handle)
         return result.success
     finally:
         # Ensure heartbeat is stopped (in case of early exit/exception)
         stop_heartbeat_event.set()
         heartbeat_thread.join(timeout=2)
+
+        # Release the working-tree consumer lock (idempotent if already released
+        # on the success path; OS would also release it on process exit).
+        release(lock_handle)
 
         # Report termination to backend
         if result is not None:

--- a/weco/ui/banner.py
+++ b/weco/ui/banner.py
@@ -1,0 +1,84 @@
+"""Weco ASCII banner + session info.
+
+Single source of truth for the startup splash. Rendered in two places:
+
+* SDK bridge (``weco.commands.start.bridge``) — printed via Rich to the
+  console before the session-create flow.
+* TUI bridge (``weco.commands.start.tui_bridge``) — mounted as a Textual
+  widget at app start.
+
+The wordmark uses the logo's gradient stops (orange → pink → purple) row
+by row. The session-info block sits underneath as a key/value list.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence, Tuple
+
+
+WORDMARK_LINES: Sequence[str] = (
+    "██╗    ██╗███████╗ ██████╗ ██████╗ ",
+    "██║    ██║██╔════╝██╔════╝██╔═══██╗",
+    "██║ █╗ ██║█████╗  ██║     ██║   ██║",
+    "██║███╗██║██╔══╝  ██║     ██║   ██║",
+    "╚███╔███╔╝███████╗╚██████╗╚██████╔╝",
+    " ╚══╝╚══╝ ╚══════╝ ╚═════╝ ╚═════╝ ",
+)
+
+# Per-line colours sampled from the logo's gradient stops
+# (#f99d24 → #ff3c82 → #c649b6 → #9854e1 → #8759f2).
+WORDMARK_COLORS: Sequence[str] = ("#f99d24", "#ff5c70", "#ff3c82", "#c649b6", "#9854e1", "#8759f2")
+
+
+WELCOME_LINE = "Welcome to Weco — let's optimize something."
+
+
+def session_info_rows(
+    *, agent: str, model: Optional[str], billing: Optional[str], session_id: Optional[str], dashboard_url: Optional[str]
+) -> Sequence[Tuple[str, str]]:
+    """The ordered (label, value) pairs shown under the welcome line."""
+    rows: list[Tuple[str, str]] = [("Agent", agent)]
+    rows.append(("Model", model or "default"))
+    if billing:
+        rows.append(("Billing", _format_billing(billing)))
+    if session_id:
+        rows.append(("Session", session_id))
+    if dashboard_url:
+        rows.append(("Dashboard", dashboard_url))
+    return rows
+
+
+def _format_billing(billing: str) -> str:
+    if billing == "weco":
+        return "Weco credits"
+    if billing == "claude":
+        return "Claude (local OAuth / ANTHROPIC_API_KEY)"
+    return billing
+
+
+def render_console(
+    console,
+    *,
+    agent: str = "Claude Code",
+    model: Optional[str] = None,
+    billing: Optional[str] = None,
+    session_id: Optional[str] = None,
+    dashboard_url: Optional[str] = None,
+) -> None:
+    """Print the gradient wordmark + session-info block to a Rich Console."""
+    for line, color in zip(WORDMARK_LINES, WORDMARK_COLORS):
+        console.print(f"[bold {color}]{line}[/]")
+    console.print()
+    console.print(f"  [bold]{WELCOME_LINE}[/]")
+    console.print()
+    label_w = max(
+        len(label)
+        for label, _ in session_info_rows(
+            agent=agent, model=model, billing=billing, session_id=session_id, dashboard_url=dashboard_url
+        )
+    )
+    for label, value in session_info_rows(
+        agent=agent, model=model, billing=billing, session_id=session_id, dashboard_url=dashboard_url
+    ):
+        console.print(f"  [dim]{label.ljust(label_w)}[/]  {value}")
+    console.print()

--- a/weco/ui/tui/__init__.py
+++ b/weco/ui/tui/__init__.py
@@ -1,0 +1,11 @@
+"""Textual-based TUI for the `weco start claude --tui` orchestrator.
+
+This package owns the *rendering* and *input* surfaces. The
+:mod:`weco.commands.start.tui_bridge` module owns the subprocess +
+relay/approval/run-watcher plumbing and pushes events into the App via the
+public ``post_*`` methods on :class:`WecoTUI`.
+"""
+
+from .app import WecoTUI
+
+__all__ = ["WecoTUI"]

--- a/weco/ui/tui/app.py
+++ b/weco/ui/tui/app.py
@@ -1,0 +1,331 @@
+"""Textual App for the `weco start claude --tui` orchestrator.
+
+The App is purely a view: it owns the widget tree, the input box, and the
+status bar, and exposes a small ``post_*`` surface that the bridge calls to
+push stream events. The bridge owns subprocess + relay + approval + run
+watcher state; it injects a ``submit_callback`` so the App can route user
+input back to the orchestrator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable, Optional
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, VerticalScroll
+from textual.widgets import Input
+
+from .question import QuestionCard
+from .widgets import AssistantMessage, RunUpdate, SystemNotice, ThinkingIndicator, ToolCallCard, UserMessage, WecoBanner
+
+
+# Bridge-provided callback. Receives the prompt text. May return an awaitable
+# (e.g. when the bridge needs to do async cleanup before queuing). Errors
+# from this callback are surfaced as a SystemNotice and otherwise ignored —
+# the App must keep accepting input.
+SubmitCallback = Callable[[str], Optional[Awaitable[None]]]
+
+# Called once, after widgets are mounted and the App's loop is running.
+# Use this to schedule any long-lived bridge work (subprocess loops, relay
+# clients, watchers) — those need the App's loop to drive their tasks.
+StartupCallback = Callable[["WecoTUI"], Optional[Awaitable[None]]]
+
+# Called when the user presses Escape — bridge should SIGINT the current
+# claude turn (if any). Returns truthy if something was actually preempted.
+PreemptCallback = Callable[[], Optional[Awaitable[None]]]
+
+
+class WecoTUI(App):
+    """Conversation TUI for the claude orchestrator."""
+
+    CSS = """
+    Screen {
+        layers: base modal;
+    }
+    #messages {
+        height: 1fr;
+        padding: 0 1;
+    }
+    #bottom-bar {
+        dock: bottom;
+        height: auto;
+    }
+    #thinking {
+        height: auto;
+    }
+    Input {
+        margin: 1 0 0 0;
+    }
+    """
+
+    BINDINGS = [
+        # Ctrl-C is two-tier: first press interrupts the current claude turn
+        # and arms the exit flag; a second press within CTRL_C_EXIT_WINDOW_S
+        # exits the TUI and asks the bridge to stop any active weco runs.
+        # If no second press lands within the window, the exit flag resets
+        # so an inadvertent earlier Ctrl-C doesn't haunt a later session.
+        Binding("ctrl+c", "ctrl_c_press", "Interrupt", priority=True),
+        Binding("ctrl+l", "scroll_end", "Jump to bottom"),
+        Binding("escape", "preempt", "Interrupt", show=False, priority=True),
+    ]
+
+    # How long the "press Ctrl-C again to exit" warning stays armed after
+    # the first press. 3s is short enough that a fat-fingered Ctrl-C
+    # doesn't sit there forever; long enough that the user can register
+    # the message and choose.
+    CTRL_C_EXIT_WINDOW_S = 3.0
+
+    def __init__(
+        self,
+        *,
+        submit_callback: Optional[SubmitCallback] = None,
+        startup_callback: Optional[StartupCallback] = None,
+        preempt_callback: Optional[PreemptCallback] = None,
+        title: str = "weco · claude",
+    ) -> None:
+        super().__init__()
+        self.title = title
+        self._submit_callback: Optional[SubmitCallback] = submit_callback
+        self._startup_callback: Optional[StartupCallback] = startup_callback
+        self._preempt_callback: Optional[PreemptCallback] = preempt_callback
+        # Set on first Ctrl-C; cleared by a timer after CTRL_C_EXIT_WINDOW_S.
+        # The second Ctrl-C while armed triggers exit-with-run-stop.
+        self._ctrl_c_armed: bool = False
+        self._ctrl_c_reset_timer = None
+        # Late-bound by the bridge — called on the second Ctrl-C so the
+        # bridge can stop any background `weco run` processes the agent
+        # spawned before we tear down the UI.
+        self._exit_with_stop_callback = None
+        self._messages: Optional[VerticalScroll] = None
+        self._input: Optional[Input] = None
+        self._thinking: Optional[ThinkingIndicator] = None
+        # Per-turn streaming state.
+        self._current_assistant: Optional[AssistantMessage] = None
+        self._tool_cards: dict[str, ToolCallCard] = {}
+
+    # --- Wiring ----------------------------------------------------------
+
+    def set_submit_callback(self, cb: SubmitCallback) -> None:
+        """Late-bind the bridge's submit handler.
+
+        Used when the App is constructed before the bridge has its
+        pending-prompts queue ready.
+        """
+        self._submit_callback = cb
+
+    def set_startup_callback(self, cb: StartupCallback) -> None:
+        """Late-bind a callback to fire once the App is mounted and running."""
+        self._startup_callback = cb
+
+    def set_preempt_callback(self, cb: PreemptCallback) -> None:
+        """Late-bind the bridge's Escape-key preempt handler."""
+        self._preempt_callback = cb
+
+    # --- Layout ----------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        yield VerticalScroll(id="messages")
+        with Container(id="bottom-bar"):
+            yield ThinkingIndicator(id="thinking")
+            yield Input(placeholder="Type a prompt and press Enter (Ctrl+C to quit)", id="prompt")
+
+    async def on_mount(self) -> None:
+        self._messages = self.query_one("#messages", VerticalScroll)
+        self._input = self.query_one("#prompt", Input)
+        self._thinking = self.query_one("#thinking", ThinkingIndicator)
+        self._input.focus()
+        if self._startup_callback is not None:
+            try:
+                result = self._startup_callback(self)
+                if asyncio.iscoroutine(result):
+                    # Don't await inline — the startup callback typically
+                    # kicks off a long-running task that should run for the
+                    # lifetime of the app. Schedule it on the running loop.
+                    asyncio.create_task(result)
+            except Exception as exc:  # noqa: BLE001
+                self.post_system_notice(f"startup error: {exc}", style="bold red")
+
+    # --- Input handling --------------------------------------------------
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input is not self._input:
+            return
+        text = event.value.strip()
+        if not text:
+            return
+        self._input.value = ""
+        # Echo immediately so the user sees their prompt land before the
+        # subprocess turns it into output.
+        self.post_user_message(text)
+        if self._submit_callback is None:
+            self.post_system_notice("(no orchestrator wired up — prompt dropped)")
+            return
+        try:
+            result = self._submit_callback(text)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:  # noqa: BLE001
+            self.post_system_notice(f"submit error: {exc}", style="bold red")
+
+    def action_scroll_end(self) -> None:
+        if self._messages is not None:
+            self._messages.scroll_end(animate=False)
+
+    async def action_preempt(self) -> None:
+        if self._preempt_callback is None:
+            return
+        try:
+            result = self._preempt_callback()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:
+            # Best-effort — don't crash the UI if the bridge is gone.
+            pass
+
+    def set_exit_with_stop_callback(self, cb) -> None:
+        """Late-bind the bridge's exit-and-stop-runs handler. Invoked on
+        the second Ctrl-C within the warning window."""
+        self._exit_with_stop_callback = cb
+
+    async def action_ctrl_c_press(self) -> None:
+        """Two-tier Ctrl-C. First press interrupts the in-flight turn and
+        warns the user; second press within the window exits the TUI and
+        asks the bridge to stop any active weco runs."""
+        if self._ctrl_c_armed:
+            # Second press → exit + stop runs.
+            self._ctrl_c_armed = False
+            if self._ctrl_c_reset_timer is not None:
+                try:
+                    self._ctrl_c_reset_timer.stop()
+                except Exception:
+                    pass
+                self._ctrl_c_reset_timer = None
+            if self._exit_with_stop_callback is not None:
+                try:
+                    result = self._exit_with_stop_callback()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    pass
+            self.exit()
+            return
+
+        # First press → interrupt current turn (same as Esc) and warn.
+        await self.action_preempt()
+        self._ctrl_c_armed = True
+        self.post_system_notice("Press Ctrl-C again to exit and terminate any active Weco runs.", style="bold yellow")
+        # Reset the armed flag after the window so a stale Ctrl-C from
+        # earlier doesn't sneak through later.
+        self._ctrl_c_reset_timer = self.set_timer(self.CTRL_C_EXIT_WINDOW_S, self._disarm_ctrl_c)
+
+    def _disarm_ctrl_c(self) -> None:
+        self._ctrl_c_armed = False
+        self._ctrl_c_reset_timer = None
+
+    # --- Bridge → App: message posting ----------------------------------
+
+    def post_system_notice(self, text: str, *, style: str = "dim italic") -> None:
+        self._mount(SystemNotice(text, style=style))
+
+    def post_banner(
+        self,
+        *,
+        agent: str = "Claude Code",
+        model: Optional[str] = None,
+        billing: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        """Mount the gradient WECO wordmark + welcome + session-info block.
+        Called once at startup."""
+        self._mount(WecoBanner(agent=agent, model=model, billing=billing, session_id=session_id))
+
+    def post_user_message(self, text: str) -> None:
+        self._end_assistant_block()
+        self._mount(UserMessage(text))
+
+    def post_assistant_delta(self, text: str) -> None:
+        if not text:
+            return
+        if self._current_assistant is None:
+            self._current_assistant = AssistantMessage()
+            self._mount(self._current_assistant)
+        self._current_assistant.append_delta(text)
+        self._scroll_to_end()
+
+    def end_assistant_block(self) -> None:
+        self._end_assistant_block()
+
+    def post_tool_use(self, tool_id: str, name: str, summary: str, tool_input: dict) -> None:
+        self._end_assistant_block()
+        card = ToolCallCard(name=name, summary=summary, tool_input=tool_input)
+        if tool_id:
+            self._tool_cards[tool_id] = card
+        self._mount(card)
+
+    def post_tool_result(self, tool_id: str, content: str, *, is_error: bool = False) -> None:
+        card = self._tool_cards.pop(tool_id, None) if tool_id else None
+        if card is None:
+            # Result without a matching tool_use — surface as a generic
+            # notice so we don't silently drop it.
+            self.post_system_notice(f"(orphan tool_result) {content[:200]}", style="dim red" if is_error else "dim")
+            return
+        card.set_result(content, is_error=is_error)
+        self._scroll_to_end()
+
+    def post_run_update(self, update: dict) -> None:
+        self._end_assistant_block()
+        self._mount(RunUpdate(update))
+
+    def post_turn_end(self, subtype: str, *, cost: Optional[float] = None, duration_ms: Optional[int] = None) -> None:
+        self._end_assistant_block()
+        parts: list[str] = []
+        if isinstance(cost, (int, float)):
+            parts.append(f"${cost:.4f} api equiv")
+        if isinstance(duration_ms, (int, float)):
+            parts.append(f"{int(duration_ms)}ms")
+        suffix = f" ({', '.join(parts)})" if parts else ""
+        if subtype == "success":
+            self.post_system_notice(f"— done{suffix} —")
+        else:
+            self.post_system_notice(f"— claude {subtype}{suffix} —", style="bold yellow")
+
+    # --- Bridge → App: thinking indicator -------------------------------
+
+    def show_thinking(self) -> None:
+        """Start the spinner above the input (idempotent)."""
+        if self._thinking is not None:
+            self._thinking.start()
+
+    def hide_thinking(self) -> None:
+        """Stop and hide the spinner (idempotent)."""
+        if self._thinking is not None:
+            self._thinking.stop()
+
+    # --- Bridge → App: approval + questions ------------------------------
+
+    def mount_inline_card(self, card: QuestionCard) -> None:
+        """Mount a pre-built inline picker — a `QuestionCard` or its
+        `ApprovalCard` subclass (each with its own future) — into the chat
+        scroll. The orchestrator owns the future and the card's lifecycle
+        in cross-surface sync paths.
+        """
+        self._mount(card)
+
+    # --- Internals -------------------------------------------------------
+
+    def _mount(self, widget) -> None:
+        if self._messages is None:
+            # Pre-mount; defer by attaching to the app once mounted.
+            self.call_later(self._mount, widget)
+            return
+        self._messages.mount(widget)
+        self._scroll_to_end()
+
+    def _scroll_to_end(self) -> None:
+        if self._messages is not None:
+            self._messages.scroll_end(animate=False)
+
+    def _end_assistant_block(self) -> None:
+        self._current_assistant = None

--- a/weco/ui/tui/approval.py
+++ b/weco/ui/tui/approval.py
@@ -1,0 +1,113 @@
+"""In-TUI tool-call approval.
+
+Rendered with the **same inline picker component as AskUserQuestion**
+(:class:`~weco.ui.tui.question.QuestionCard`) so confirmations and
+option-choosing share one widget — and one cross-surface sync path with
+the dashboard.
+
+Fired by the bridge when the SDK's ``can_use_tool`` callback gates on a
+tool: the bridge mounts an :class:`ApprovalCard` inline in the chat scroll
+and awaits a ``(decision, scope)`` decision.
+
+* decision: ``"approve"`` | ``"deny"`` | ``"ask"``
+* scope:    ``"once"``    | ``"always"``
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Tuple
+
+from .question import QuestionCard
+
+
+Decision = Tuple[str, str]
+
+
+# Option label → (decision, scope), in display order. "always" is treated
+# as a tool-wide whitelist by the approval router (it maps it the same way
+# as the dashboard's "tool" scope); finer-grained "command"/exact-call
+# scoping stays a dashboard-only affordance for now.
+_APPROVAL_CHOICES: list[tuple[str, Decision]] = [
+    ("Allow once", ("approve", "once")),
+    ("Allow always", ("approve", "always")),
+    ("Deny", ("deny", "once")),
+]
+_LABEL_TO_DECISION: dict[str, Decision] = {label: decision for label, decision in _APPROVAL_CHOICES}
+
+# Short status word shown in the collapsed header after the user picks.
+_DECISION_STATUS: dict[Decision, str] = {
+    ("approve", "once"): "allowed once",
+    ("approve", "always"): "always allowed",
+    ("deny", "once"): "denied",
+}
+
+
+class ApprovalCard(QuestionCard):
+    """Inline tool-call approval — a single-select :class:`QuestionCard`
+    whose options map to ``(decision, scope)`` tuples.
+
+    Resolves ``decision_future`` with the chosen :data:`Decision` (or
+    ``("deny", "once")`` on Escape). When the dashboard answers the same
+    approval first, the bridge calls :meth:`resolve_remotely_decision` to
+    freeze the card.
+    """
+
+    def __init__(self, tool_name: str, summary: str, decision_future: "asyncio.Future[Decision]") -> None:
+        self._decision_future = decision_future
+        question = {
+            # Short question text → clean collapsed "✓ … → answer" line.
+            "question": f"Allow {tool_name}?",
+            # The arbitrary tool summary (paths, commands, JSON) rides as
+            # the muted detail sub-line, not the question text.
+            "detail": summary,
+            "options": [{"label": label} for label, _ in _APPROVAL_CHOICES],
+            "multiSelect": False,
+        }
+        # The parent drives an answers-future we never await — we translate
+        # the selected label into a Decision instead (see `_submit`).
+        answers_future: "asyncio.Future[dict]" = asyncio.get_running_loop().create_future()
+        super().__init__([question], answers_future, active_title="Tool call needs approval", done_title="Tool call")
+
+    # --- Decision plumbing ---------------------------------------------
+
+    def _resolve_decision(self, decision: Decision) -> None:
+        if not self._decision_future.done():
+            self._decision_future.set_result(decision)
+
+    def _submit(self) -> None:
+        # A single question → exactly one recorded answer; translate its
+        # selected label into a Decision rather than handing back the
+        # answers map the question flow uses.
+        if self._answered or self._decision_future.done():
+            return
+        label = next(iter(self._answers.values()), "")
+        decision = _LABEL_TO_DECISION.get(str(label), ("deny", "once"))
+        self._resolve_decision(decision)
+        self._mark_done(_DECISION_STATUS.get(decision, "answered"))
+
+    def _cancel(self) -> None:
+        # Escape on an approval = deny once.
+        if self._answered or self._decision_future.done():
+            return
+        self._resolve_decision(("deny", "once"))
+        self._mark_done("denied")
+
+    # --- Cross-surface sync --------------------------------------------
+
+    def resolve_remotely_decision(self, decision: str, scope: str) -> None:
+        """Dashboard answered first — freeze the card with its decision."""
+        if self._answered or self._decision_future.done():
+            return
+        self._resolve_decision((decision, scope))
+        self._mark_done("answered on dashboard")
+
+    def resolve_remotely(self, answers) -> None:  # type: ignore[override]
+        """Compatibility shim for the generic turn-cancel cleanup path,
+        which calls ``resolve_remotely({})`` on every active card. For an
+        approval, a cancelled turn means the gated tool call is moot →
+        deny once."""
+        if self._answered or self._decision_future.done():
+            return
+        self._resolve_decision(("deny", "once"))
+        self._mark_done("dismissed")

--- a/weco/ui/tui/question.py
+++ b/weco/ui/tui/question.py
@@ -1,0 +1,319 @@
+"""Inline AskUserQuestion widget — sequential, one-question-at-a-time.
+
+Mounts in the chat scroll. Renders **only the active question** at any
+moment; previously answered questions collapse into a one-line summary
+above the active picker so the user only has one decision in focus.
+Matches Claude Code's native AskUserQuestion picker UX.
+
+Per-question controls:
+
+* single-select → `OptionList`. Arrow keys + number-jump; Enter
+  selects and **auto-advances** to the next question (or submits if
+  this was the last).
+* multi-select  → `SelectionList`. Space toggles items, Enter on the
+  "Continue" button below advances. (Multi-select can't auto-advance
+  because there's no "done picking" signal.)
+
+Submission resolves the future with ``{question_text: answer}`` where
+answer is a string (single-select) or list[str] (multi-select). Esc
+resolves with ``{}`` which the SDK treats as "no input".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Union
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, OptionList, SelectionList, Static
+from textual.widgets.option_list import Option
+
+
+AnswerValue = Union[str, list[str]]
+AnswersDict = dict[str, AnswerValue]
+
+
+class QuestionCard(Static):
+    """Inline question card. Sequential per-question prompting."""
+
+    can_focus = True
+
+    DEFAULT_CSS = """
+    QuestionCard {
+        padding: 1 0;
+        margin-top: 1;
+        height: auto;
+    }
+    QuestionCard .q-header {
+        text-style: bold;
+        color: $text-muted;
+        padding-bottom: 1;
+        height: auto;
+    }
+    QuestionCard .q-done {
+        color: $text-muted;
+        height: 1;
+        padding: 0;
+    }
+    QuestionCard .q-text {
+        padding-bottom: 0;
+        height: auto;
+    }
+    QuestionCard .q-detail {
+        color: $text-muted;
+        height: auto;
+        padding-bottom: 1;
+    }
+    QuestionCard .q-hint {
+        color: $text-muted;
+        height: 1;
+        padding-top: 0;
+    }
+    QuestionCard #q-done,
+    QuestionCard #q-current {
+        height: auto;
+        padding: 0;
+    }
+    QuestionCard OptionList,
+    QuestionCard SelectionList {
+        background: transparent;
+        border: none;
+        padding: 0;
+        height: auto;
+    }
+    QuestionCard #continue-row {
+        height: 3;
+        align-horizontal: right;
+        margin-top: 0;
+    }
+    QuestionCard #continue-row Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(
+        self,
+        questions: list[dict],
+        future: "asyncio.Future[AnswersDict]",
+        *,
+        active_title: str = "Agent needs your input",
+        done_title: str = "Agent's questions",
+    ) -> None:
+        super().__init__()
+        self._questions = [q for q in (questions or []) if isinstance(q, dict)]
+        self._future = future
+        self._answered = False
+        self._idx = 0
+        self._answers: AnswersDict = {}
+        # Header copy — overridable so the same picker fronts both
+        # AskUserQuestion prompts and tool-call approvals (see
+        # `ApprovalCard`, which subclasses this with approval-flavoured
+        # titles). Defaults preserve the question-flow wording.
+        self._active_title = active_title
+        self._done_title = done_title
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._header_text(), id="q-header", classes="q-header", markup=False)
+        # Container for "already answered" one-line summaries — grows
+        # as questions are answered.
+        yield Vertical(id="q-done")
+        # Container for the active question's widgets — cleared and
+        # repopulated on every advance.
+        yield Vertical(id="q-current")
+
+    def on_mount(self) -> None:
+        if not self._questions:
+            self._submit()
+            return
+        self._show_current_question()
+
+    # --- Header / progress ---------------------------------------------
+
+    def _header_text(self) -> str:
+        n = len(self._questions)
+        if self._answered:
+            return f"{self._done_title} · answered"
+        if n == 1:
+            return self._active_title
+        return f"{self._active_title} · {self._idx + 1} of {n}"
+
+    def _refresh_header(self) -> None:
+        try:
+            self.query_one("#q-header", Static).update(self._header_text())
+        except Exception:
+            pass
+
+    # --- Sequential prompting ------------------------------------------
+
+    def _show_current_question(self) -> None:
+        """Clear the active-question container and render the current
+        question's prompt + picker. Auto-submits when past the last
+        question.
+
+        Implementation note — child widget ids are suffixed with the
+        per-question index (`picker-0`, `picker-1`, …). `Widget.remove()`
+        is scheduled, not immediate: when we clear the container and
+        immediately mount the next question's widgets, the old children
+        are still in the tree for one event-loop tick. Using a fresh
+        id per question avoids the resulting `DuplicateIds` error
+        without needing to make the handler async.
+        """
+        try:
+            current = self.query_one("#q-current", Vertical)
+        except Exception:
+            return
+        for child in list(current.children):
+            child.remove()
+
+        if self._idx >= len(self._questions):
+            self._submit()
+            return
+
+        q = self._questions[self._idx]
+        qtext = str(q.get("question") or "")
+        detail = str(q.get("detail") or "")
+        options = q.get("options") if isinstance(q.get("options"), list) else []
+        multi = bool(q.get("multiSelect"))
+
+        picker_id = self._picker_id()
+        continue_id = f"continue-{self._idx}"
+        row_id = f"continue-row-{self._idx}"
+
+        # Question text
+        current.mount(Static(qtext, classes="q-text", markup=False))
+        # Optional muted detail line under the question — e.g. the tool
+        # summary on an approval (file path / shell command / JSON). Kept
+        # out of `qtext` so the collapsed "✓ … → answer" summary stays a
+        # readable one-liner.
+        if detail:
+            current.mount(Static(detail, classes="q-detail", markup=False))
+
+        if multi:
+            entries = [(Text(str(o.get("label") or "")), str(o.get("label") or "")) for o in options if isinstance(o, dict)]
+            picker = SelectionList[str](*entries, id=picker_id)
+            current.mount(picker)
+            current.mount(Static("  Space to toggle  ·  Tab → Continue to advance", classes="q-hint", markup=False))
+            # Continue button — the explicit "done picking" signal that
+            # multi-select needs (Enter on a SelectionList toggles, so
+            # we can't reuse it for advance).
+            row = Horizontal(id=row_id)
+            current.mount(row)
+            row.mount(Button("Continue", id=continue_id, variant="primary"))
+        else:
+            opts = [
+                Option(Text(str(o.get("label") or "")), id=str(o.get("label") or "")) for o in options if isinstance(o, dict)
+            ]
+            picker = OptionList(*opts, id=picker_id)
+            current.mount(picker)
+
+        self._refresh_header()
+
+        # Focus the picker so arrow keys / number-jump / Space / Enter
+        # work without the user having to click first.
+        def _focus_picker():
+            try:
+                self.app.set_focus(self.query_one(f"#{picker_id}"))
+            except Exception:
+                pass
+
+        self.app.call_after_refresh(_focus_picker)
+
+    def _picker_id(self) -> str:
+        return f"picker-{self._idx}"
+
+    def _record_and_advance(self, answer: AnswerValue) -> None:
+        q = self._questions[self._idx]
+        qtext = str(q.get("question") or "")
+        self._answers[qtext] = answer
+        # Mount a collapsed summary into the "done" container so the
+        # user can see what they've already answered without it
+        # competing for attention with the active question.
+        try:
+            done = self.query_one("#q-done", Vertical)
+            done.mount(Static(f"  ✓ {qtext} → {_format_answer(answer)}", classes="q-done", markup=False))
+        except Exception:
+            pass
+        self._idx += 1
+        self._show_current_question()
+
+    # --- Events ---------------------------------------------------------
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        """Single-select Enter — answer is the option id (= the label
+        string, since we set them equal at construction). Auto-advance.
+
+        Per-question-index ids (`picker-0`, `picker-1`, …) let us tell
+        the active picker apart from any still-tearing-down picker
+        from a previous question, so a late OptionSelected fired by
+        an unmounting widget can't double-advance.
+        """
+        if self._answered or self._future.done():
+            return
+        if self._idx >= len(self._questions):
+            return
+        if (event.option_list.id or "") != self._picker_id():
+            return
+        answer = str(event.option.id or "")
+        self._record_and_advance(answer)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id or ""
+        if bid == f"continue-{self._idx}":
+            try:
+                picker = self.query_one(f"#{self._picker_id()}", SelectionList)
+            except Exception:
+                return
+            picks = list(picker.selected)
+            self._record_and_advance(picks)
+
+    def action_cancel(self) -> None:
+        self._cancel()
+
+    # --- Cross-surface sync --------------------------------------------
+
+    def resolve_remotely(self, answers: AnswersDict) -> None:
+        """Called when the dashboard answered first — freeze the card."""
+        if self._answered or self._future.done():
+            return
+        self._future.set_result(answers)
+        self._mark_done("answered on dashboard")
+
+    # --- Terminal state ------------------------------------------------
+
+    def _submit(self) -> None:
+        if self._answered or self._future.done():
+            return
+        self._future.set_result(self._answers)
+        self._mark_done("answered")
+
+    def _cancel(self) -> None:
+        if self._answered or self._future.done():
+            return
+        self._future.set_result({})
+        self._mark_done("dismissed")
+
+    def _mark_done(self, status: str) -> None:
+        self._answered = True
+        # Clear the active-question container — only the "done" summary
+        # column stays as conversation history.
+        try:
+            current = self.query_one("#q-current", Vertical)
+            for child in list(current.children):
+                child.remove()
+        except Exception:
+            pass
+        try:
+            self.query_one("#q-header", Static).update(f"{self._done_title} · {status}")
+        except Exception:
+            pass
+
+
+def _format_answer(answer: AnswerValue) -> str:
+    if isinstance(answer, list):
+        return ", ".join(answer) if answer else "(none)"
+    return str(answer)

--- a/weco/ui/tui/widgets.py
+++ b/weco/ui/tui/widgets.py
@@ -1,0 +1,455 @@
+"""Message widgets shown in the TUI conversation log.
+
+Each widget renders one conceptual unit of the chat:
+* :class:`UserMessage` — the user's prompt for this turn.
+* :class:`AssistantMessage` — a streamable Markdown bubble.
+* :class:`ToolCallCard` — a tool_use + its eventual tool_result, paired by id.
+* :class:`SystemNotice` — `— claude ready —`, `— done —`, etc.
+* :class:`RunUpdate` — wrapper-side weco-run progress lines.
+* :class:`ThinkingIndicator` — Claude-Code-style spinner+word shown while the
+  model is generating but no tokens have streamed yet.
+
+Widgets accept Rich renderables, so prose stays markdown-rendered (via
+:class:`rich.markdown.Markdown`) and tool output stays verbatim with no
+auto-highlighting surprises.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Optional
+
+from rich.console import Group, RenderableType
+from rich.markdown import Markdown
+from rich.text import Text
+from textual.widgets import Static
+
+
+# How many lines / chars of tool output we show before collapsing into a
+# "+N lines" marker. Claude still sees the full content; this is purely the
+# local display budget.
+_RESULT_MAX_LINES = 12
+_RESULT_MAX_CHARS = 2000
+
+# Diff line budgets when rendering Edit/Write.
+_DIFF_MAX_OLD = 8
+_DIFF_MAX_NEW = 12
+
+
+class UserMessage(Static):
+    """User prompt, rendered with a `›` left marker."""
+
+    DEFAULT_CSS = """
+    UserMessage {
+        padding: 0 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, text: str) -> None:
+        super().__init__()
+        self._text = text
+
+    def on_mount(self) -> None:
+        body = Text()
+        body.append("› ", style="bold cyan")
+        body.append(self._text, style="bold")
+        self.update(body)
+
+
+class AssistantMessage(Static):
+    """A streamed assistant turn, rendered as Markdown.
+
+    Call :meth:`append_delta` for each text fragment as the model streams.
+    The widget re-renders the accumulated buffer as Markdown each call,
+    so bold/lists/headings/fenced code all surface live.
+    """
+
+    DEFAULT_CSS = """
+    AssistantMessage {
+        padding: 0 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._buf = ""
+
+    def append_delta(self, text: str) -> None:
+        if not text:
+            return
+        self._buf += text
+        # `code_theme` matches the dark CC look; Rich falls back to plain
+        # if the terminal doesn't support truecolor.
+        self.update(Markdown(self._buf, code_theme="github-dark"))
+
+    @property
+    def buffer(self) -> str:
+        return self._buf
+
+
+class SystemNotice(Static):
+    """Dim italic ambient notice — model ready, turn done, etc."""
+
+    DEFAULT_CSS = """
+    SystemNotice {
+        padding: 0 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, text: str, *, style: str = "dim italic") -> None:
+        super().__init__()
+        self._text = text
+        self._style = style
+
+    def on_mount(self) -> None:
+        self.update(Text(self._text, style=self._style))
+
+
+class WecoBanner(Static):
+    """Gradient WECO wordmark + welcome line + session-info block.
+
+    Shown once at TUI startup. Fields default to ``None`` and are simply
+    omitted from the info block when missing.
+    """
+
+    DEFAULT_CSS = """
+    WecoBanner {
+        padding: 1 2 0 2;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: str = "Claude Code",
+        model: Optional[str] = None,
+        billing: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self._agent = agent
+        self._model = model
+        self._billing = billing
+        self._session_id = session_id
+
+    def on_mount(self) -> None:
+        # Imported lazily so the widget module stays free of cli-only deps.
+        from weco.ui.banner import WORDMARK_LINES, WORDMARK_COLORS, WELCOME_LINE, session_info_rows
+
+        text = Text()
+        for i, (line, color) in enumerate(zip(WORDMARK_LINES, WORDMARK_COLORS)):
+            if i:
+                text.append("\n")
+            text.append(line, style=f"bold {color}")
+
+        text.append("\n\n")
+        text.append(WELCOME_LINE, style="bold")
+        text.append("\n")
+
+        rows = session_info_rows(
+            agent=self._agent,
+            model=self._model,
+            billing=self._billing,
+            session_id=self._session_id,
+            dashboard_url=None,  # The TUI intentionally omits the dashboard link.
+        )
+        label_w = max(len(label) for label, _ in rows)
+        for label, value in rows:
+            text.append("\n  ")
+            text.append(label.ljust(label_w), style="dim")
+            text.append("  ")
+            text.append(value)
+
+        self.update(text)
+
+
+class RunUpdate(Static):
+    """Single-line wrapper-rendered weco-run update with optional hints."""
+
+    DEFAULT_CSS = """
+    RunUpdate {
+        padding: 0 1;
+        margin-top: 1;
+    }
+    """
+
+    _STYLES = {
+        "new_best": ("✦", "bold green"),
+        "completed": ("✓", "bold green"),
+        "step_advance": ("›", "cyan"),
+        "idle": ("…", "dim"),
+        "errored": ("✗", "bold red"),
+        "stopped": ("◼", "yellow"),
+        "pending_review": ("⚠", "yellow"),
+        "attached": ("→", "dim cyan"),
+    }
+
+    def __init__(self, update: dict) -> None:
+        super().__init__()
+        self._update = update
+
+    def on_mount(self) -> None:
+        kind = self._update.get("kind", "")
+        icon, style = self._STYLES.get(kind, ("›", "cyan"))
+        run_id = self._update.get("run_id") or ""
+        short_id = run_id[:8] if run_id else "????????"
+        body = Text()
+        body.append(f"{icon}", style=style)
+        body.append(f" [{short_id}] ", style="dim")
+        body.append(str(self._update.get("text", "")))
+        hints = self._update.get("hints") or []
+        for hint in hints:
+            if isinstance(hint, str) and hint:
+                body.append("\n   → ", style="dim")
+                body.append(hint, style="dim")
+        self.update(body)
+
+
+class ThinkingIndicator(Static):
+    """Animated `✻ Thinking…` line shown while we're waiting on Claude.
+
+    Sits above the input box (see :class:`weco.ui.tui.app.WecoTUI.compose`).
+    Hidden when nothing is in flight; visible from prompt-submit through
+    first token, and again between tool_result and the next assistant
+    chunk. The label rotates through a small list of evocative verbs to
+    match Claude Code's vibe.
+    """
+
+    DEFAULT_CSS = """
+    ThinkingIndicator {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+    ThinkingIndicator.-hidden {
+        display: none;
+    }
+    """
+
+    # Single-glyph spinner — six-pointed-star variants give a CC-ish twinkle.
+    _SPINNER_FRAMES = ("✻", "✺", "✹", "✸", "✷", "✶", "✵", "✴", "✳", "✲", "✱", "✺")
+    # Word rotates every few seconds so long waits feel alive without
+    # being noisy.
+    _WORDS = (
+        "Thinking",
+        "Cogitating",
+        "Pondering",
+        "Marinating",
+        "Brewing",
+        "Synthesizing",
+        "Mulling",
+        "Deliberating",
+        "Weighing",
+        "Ruminating",
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__("", *args, **kwargs)
+        self.add_class("-hidden")
+        self._timer = None
+        self._frame = 0
+        self._word_idx = 0
+        self._started_at: Optional[float] = None
+
+    def start(self) -> None:
+        """Show the indicator and start animating."""
+        self._frame = 0
+        self._word_idx = random.randrange(len(self._WORDS))
+        self._started_at = time.monotonic()
+        self.remove_class("-hidden")
+        self._tick()
+        if self._timer is None:
+            self._timer = self.set_interval(0.1, self._tick)
+
+    def stop(self) -> None:
+        """Hide the indicator and pause the animation timer."""
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+        self._started_at = None
+        self.add_class("-hidden")
+
+    def _tick(self) -> None:
+        self._frame += 1
+        spinner = self._SPINNER_FRAMES[self._frame % len(self._SPINNER_FRAMES)]
+        # Cycle through verbs every ~4 seconds (40 ticks at 100ms).
+        if self._frame % 40 == 0:
+            self._word_idx = (self._word_idx + 1) % len(self._WORDS)
+        word = self._WORDS[self._word_idx]
+        elapsed = f" ({int(time.monotonic() - self._started_at)}s)" if self._started_at is not None else ""
+        body = Text()
+        body.append(spinner, style="bold magenta")
+        body.append(f" {word}…", style="dim")
+        if elapsed:
+            body.append(elapsed, style="dim")
+        body.append("   esc to interrupt", style="dim italic")
+        self.update(body)
+
+
+class ToolCallCard(Static):
+    """One tool_use, paired with its tool_result by id.
+
+    The card mounts immediately when the model emits the tool_use (bullet
+    in yellow, "running"). When the result arrives we re-render with a
+    green/red bullet and a tool-specific body.
+    """
+
+    DEFAULT_CSS = """
+    ToolCallCard {
+        padding: 0 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, name: str, summary: str, tool_input: dict) -> None:
+        super().__init__()
+        self._name = name
+        self._summary = summary
+        self._input = tool_input if isinstance(tool_input, dict) else {}
+        self._result_text: Optional[str] = None
+        self._is_error = False
+        self._status = "running"
+
+    def on_mount(self) -> None:
+        self._refresh_card()
+
+    def set_result(self, text: str, *, is_error: bool) -> None:
+        self._result_text = text or ""
+        self._is_error = is_error
+        self._status = "error" if is_error else "ok"
+        self._refresh_card()
+
+    def _refresh_card(self) -> None:
+        bullet_style = {"running": "bold yellow", "ok": "bold green", "error": "bold red"}[self._status]
+        head = Text()
+        head.append("●", style=bullet_style)
+        head.append(f" {self._name}", style="bold")
+        if self._summary:
+            head.append("(", style="default")
+            head.append(self._summary, style="dim")
+            head.append(")", style="default")
+
+        parts: list[RenderableType] = [head]
+        body = self._build_body()
+        if body is not None:
+            parts.append(body)
+        self.update(Group(*parts))
+
+    def _build_body(self) -> Optional[RenderableType]:
+        if self._status == "running":
+            return None
+
+        # Tool-specific renderers
+        if self._name == "TodoWrite" and not self._is_error:
+            todos = self._input.get("todos") if isinstance(self._input, dict) else None
+            if isinstance(todos, list):
+                return _render_todos(todos)
+        if self._name in ("Edit", "Write") and not self._is_error:
+            diff = _render_diff(self._name, self._input)
+            if diff is not None:
+                return diff
+
+        return _render_generic_body(self._result_text or "", is_error=self._is_error)
+
+
+# --- Renderable builders -----------------------------------------------------
+
+
+def _render_generic_body(text: str, *, is_error: bool) -> RenderableType:
+    text = (text or "").rstrip()
+    glyph_style = "red" if is_error else "dim"
+    body_style = "red" if is_error else "default"
+    if not text:
+        out = Text("  ⎿  ", style=glyph_style)
+        out.append("(no output)", style="dim")
+        return out
+
+    if len(text) > _RESULT_MAX_CHARS:
+        text = text[:_RESULT_MAX_CHARS] + " …"
+
+    lines = text.split("\n")
+    extra = 0
+    if len(lines) > _RESULT_MAX_LINES:
+        extra = len(lines) - _RESULT_MAX_LINES
+        lines = lines[:_RESULT_MAX_LINES]
+
+    body = Text()
+    for i, line in enumerate(lines):
+        if i == 0:
+            body.append("  ⎿  ", style=glyph_style)
+        else:
+            body.append("     ")
+        body.append(line, style=body_style)
+        if i < len(lines) - 1 or extra:
+            body.append("\n")
+    if extra:
+        body.append(f"     … +{extra} lines", style="dim")
+    return body
+
+
+def _render_todos(todos: list) -> RenderableType:
+    body = Text()
+    body.append("  ⎿  ", style="dim")
+    first = True
+    for todo in todos:
+        if not isinstance(todo, dict):
+            continue
+        if not first:
+            body.append("\n     ")
+        first = False
+        status = todo.get("status", "")
+        content = str(todo.get("content", ""))
+        if status == "completed":
+            body.append("☒ ", style="green")
+            body.append(content, style="dim")
+        elif status == "in_progress":
+            body.append("☐ ", style="yellow")
+            body.append(content, style="bold")
+        else:
+            body.append("☐ ")
+            body.append(content)
+    return body
+
+
+def _render_diff(tool_name: str, tool_input: dict) -> Optional[RenderableType]:
+    path = str(tool_input.get("file_path", "")) if isinstance(tool_input, dict) else ""
+    if tool_name == "Write":
+        old = ""
+        new = tool_input.get("content") if isinstance(tool_input, dict) else None
+    else:
+        old = tool_input.get("old_string") if isinstance(tool_input, dict) else None
+        new = tool_input.get("new_string") if isinstance(tool_input, dict) else None
+    if not isinstance(old, str) or not isinstance(new, str):
+        return None
+
+    old_lines = old.splitlines()
+    new_lines = new.splitlines()
+    verb = "Created" if tool_name == "Write" else "Updated"
+    summary = f"{verb} {path}"
+    if tool_name == "Edit":
+        summary += f" ({len(old_lines)} → {len(new_lines)} lines)"
+    elif new_lines:
+        summary += f" ({len(new_lines)} lines)"
+
+    body = Text()
+    body.append("  ⎿  ", style="dim")
+    body.append(summary, style="dim")
+
+    truncated = False
+    for line in old_lines[:_DIFF_MAX_OLD]:
+        body.append("\n       - ", style="red")
+        body.append(line, style="red")
+    if len(old_lines) > _DIFF_MAX_OLD:
+        truncated = True
+    for line in new_lines[:_DIFF_MAX_NEW]:
+        body.append("\n       + ", style="green")
+        body.append(line, style="green")
+    if len(new_lines) > _DIFF_MAX_NEW:
+        truncated = True
+    if truncated:
+        body.append("\n       … (diff truncated)", style="dim")
+    return body

--- a/weco/validation.py
+++ b/weco/validation.py
@@ -54,7 +54,7 @@ def validate_source_file(source: str) -> None:
         raise ValidationError(f"Cannot read '{source}': {e}")
 
 
-# Multi-file safeguard limits (must match meta-agent API limits)
+# Multi-file safeguard limits (must match the Weco API limits)
 MAX_SCOPED_FILES = 10
 MAX_PER_FILE_BYTES = 200 * 1024  # 200 KB
 MAX_TOTAL_BYTES = 500 * 1024  # 500 KB


### PR DESCRIPTION
Bridge a local Claude Code session to the Weco dashboard over Supabase Realtime: session create + heartbeat, a Realtime channel relay with JWT refresh and scrollback replay, and a persistent SDK client whose read and write loops are decoupled so output isn't stranded between turns.

Includes tool-approval / AskUserQuestion routing (dashboard + local TUI), robust message flushing on error, missing-Claude-install handling, agent guidance to keep the agent responsive during background runs, and a single lineage-scoped consumer that serializes parallel derived-run evaluations with inbound derive-request handling.