### PR TITLE
Merge Dev - Graceful session reconnection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "weco"
 authors = [{ name = "Weco AI Team", email = "contact@weco.ai" }]
 description = "Documentation for `weco`, a CLI for using Weco AI's code optimizer."
 readme = "README.md"
-version = "0.3.36"
+version = "0.3.37"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_start_bridge_sdk.py
+++ b/tests/test_start_bridge_sdk.py
@@ -9,11 +9,13 @@ required.
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from rich.console import Console
 
 from weco.commands.start import tui_bridge as bridge, sdk_config, envelopes, approval_router
 
@@ -567,3 +569,49 @@ def test_fan_out_swallows_interrupted_result_and_clears_flag():
     assert fake._interrupting is False  # cleared on the interrupted turn's terminal message
     assert published == []  # not mirrored — turn_interrupted already signalled the end
     assert rendered == []  # not rendered as an error bubble
+
+
+# --- HeadlessUI (no-TTY stand-in) ---------------------------------------------
+
+
+def test_headless_ui_unknown_methods_are_noops():
+    ui = bridge.HeadlessUI(Console(file=io.StringIO()))
+    # The full WecoTUI visual surface the Renderer/Orchestrator may call.
+    ui.show_thinking()
+    ui.hide_thinking()
+    ui.post_assistant_delta("hi")
+    ui.end_assistant_block()
+    ui.post_tool_result("id", "out", is_error=True)
+    ui.exit()
+    assert callable(ui.some_method_added_later)  # __getattr__ keeps it forward-compatible
+
+
+def test_headless_ui_lifecycle_lines_reach_the_console():
+    buf = io.StringIO()
+    ui = bridge.HeadlessUI(Console(file=buf, width=200))
+    ui.post_banner(agent="Claude Code", model="opus", billing="weco", session_id="s1")
+    ui.post_tool_use("t1", "Bash", "weco run ...", {})
+    ui.post_run_update({"run_id": "abcdef123456", "status": "running", "step": 3, "total_steps": 10, "best_metric": 0.9})
+    out = buf.getvalue()
+    assert "model=opus" in out and "Bash" in out and "abcdef12" in out and "step 3/10" in out
+
+
+def test_headless_ui_notice_survives_markup_in_text():
+    buf = io.StringIO()
+    ui = bridge.HeadlessUI(Console(file=buf, width=200))
+    ui.post_system_notice("error [not-markup] {brace}", style="bold red")  # must not raise on stray brackets
+    assert "not-markup" in buf.getvalue()
+
+
+def test_orchestrator_stores_seed_prompt():
+    orch = bridge.Orchestrator(
+        app=bridge.HeadlessUI(Console(file=io.StringIO())),
+        claude_args=[],
+        api_key="k",
+        session=bridge.DashboardSession.offline(),
+        billing="claude",
+        weco_api_base=None,
+        effort=None,
+        seed_prompt="optimize the repo",
+    )
+    assert orch._seed_prompt == "optimize the repo"

--- a/tests/test_start_cli.py
+++ b/tests/test_start_cli.py
@@ -1,11 +1,14 @@
-"""Tests for `weco start claude` pre-flight checks."""
+"""Tests for `weco start claude` pre-flight checks and dispatch."""
 
 from __future__ import annotations
+
+import argparse
 
 import pytest
 from rich.console import Console
 
 from weco.commands.start import cli
+from weco.commands.start import tui_bridge
 
 
 def test_require_claude_cli_exits_when_not_installed(monkeypatch):
@@ -18,3 +21,51 @@ def test_require_claude_cli_exits_when_not_installed(monkeypatch):
 def test_require_claude_cli_passes_when_installed(monkeypatch):
     monkeypatch.setattr(cli.shutil, "which", lambda _name: "/usr/local/bin/claude")
     cli._require_claude_cli(Console())  # no exit
+
+
+def _claude_args(**overrides):
+    base = dict(
+        start_command="claude", allow_tools=False, effort=None, billing="claude", headless=False, prompt=None, claude_args=[]
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _stub_runners(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(cli, "load_weco_api_key", lambda: "weco-key")
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: "/usr/local/bin/claude")
+
+    def _record(key):
+        def runner(**kw):
+            calls[key] = kw
+            return 0
+
+        return runner
+
+    monkeypatch.setattr(tui_bridge, "run_tui_bridge", _record("tui"))
+    monkeypatch.setattr(tui_bridge, "run_headless_bridge", _record("headless"))
+    return calls
+
+
+def test_dispatch_defaults_to_tui_runner(monkeypatch):
+    calls = _stub_runners(monkeypatch)
+    with pytest.raises(SystemExit) as exc:
+        cli.handle_start_command(_claude_args(), Console())
+    assert exc.value.code == 0
+    assert "tui" in calls and "headless" not in calls
+
+
+def test_headless_flag_routes_to_headless_runner_with_seed(monkeypatch):
+    calls = _stub_runners(monkeypatch)
+    with pytest.raises(SystemExit):
+        cli.handle_start_command(_claude_args(headless=True, prompt="optimize this"), Console())
+    assert "headless" in calls and "tui" not in calls
+    assert calls["headless"]["seed_prompt"] == "optimize this"
+
+
+def test_allow_tools_appends_skip_permissions(monkeypatch):
+    calls = _stub_runners(monkeypatch)
+    with pytest.raises(SystemExit):
+        cli.handle_start_command(_claude_args(allow_tools=True), Console())
+    assert "--dangerously-skip-permissions" in calls["tui"]["claude_args"]

--- a/tests/test_start_relay.py
+++ b/tests/test_start_relay.py
@@ -8,7 +8,12 @@ now lives on ``WecoClient`` / ``DashboardSession`` (see ``test_start_session``).
 
 from __future__ import annotations
 
+import asyncio
+
+from unittest.mock import AsyncMock, MagicMock
+
 from weco.commands.start import relay
+from weco.core.api import SessionInactiveError
 
 
 # --- _chunk_utf8 ---------------------------------------------------------------
@@ -43,3 +48,90 @@ def test_parse_iso_handles_z_suffix():
     ts = relay._parse_iso("2026-05-05T12:00:00Z")
     # Just sanity: it's a unix timestamp around the right magnitude.
     assert ts > 1_700_000_000
+
+
+# --- terminal 409 stops the bridge ---------------------------------------------
+
+
+def test_heartbeat_loop_stops_bridge_on_session_inactive(monkeypatch):
+    monkeypatch.setattr(relay, "HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    client = MagicMock()
+    client.session_heartbeat.side_effect = SessionInactiveError("sess-1")
+    stop_event = asyncio.Event()
+
+    async def _run():
+        await asyncio.wait_for(relay._heartbeat_loop(client, "sess-1", stop_event), timeout=2.0)
+
+    asyncio.run(_run())
+    assert stop_event.is_set()
+
+
+def test_heartbeat_loop_keeps_going_on_transient_error(monkeypatch):
+    monkeypatch.setattr(relay, "HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    client = MagicMock()
+    calls = {"n": 0}
+
+    def _flaky(_sid):
+        calls["n"] += 1
+        if calls["n"] >= 3:
+            stop_event.set()
+        raise RuntimeError("network blip")
+
+    client.session_heartbeat.side_effect = _flaky
+    stop_event = asyncio.Event()
+
+    async def _run():
+        await asyncio.wait_for(relay._heartbeat_loop(client, "sess-1", stop_event), timeout=2.0)
+
+    asyncio.run(_run())
+    # Transient errors don't tear the bridge down — it kept pinging.
+    assert calls["n"] >= 3
+
+
+def test_jwt_refresher_stops_bridge_on_session_inactive(monkeypatch):
+    client = MagicMock()
+    client.refresh_realtime_token.side_effect = SessionInactiveError("sess-1")
+    stop_event = asyncio.Event()
+    # Already-elapsed expiry → the loop's sleep floors at 1s, then refreshes.
+    expiry_state = {"unix": relay.time.time() - 1000}
+
+    async def _run():
+        await asyncio.wait_for(
+            relay._jwt_refresher(MagicMock(), MagicMock(), client, "sess-1", expiry_state, stop_event), timeout=3.0
+        )
+
+    asyncio.run(_run())
+    assert stop_event.is_set()
+
+
+def test_jwt_refresher_restamps_join_token_and_rejoins_after_reconnect():
+    # After a reconnect that outlived the original JWT, the channel rejoins with
+    # a stale baked-in token unless we re-stamp the join payload on refresh.
+    fresh = {"token": "T2", "expires_at": "2999-01-01T00:00:00+00:00"}
+    weco_client = MagicMock()
+    stop_event = asyncio.Event()
+
+    def _mint(_sid):
+        stop_event.set()  # let the loop run exactly one iteration
+        return fresh
+
+    weco_client.refresh_realtime_token.side_effect = _mint
+
+    rt_client = MagicMock()
+    rt_client.set_auth = AsyncMock()
+
+    channel = MagicMock()
+    channel.is_joined = False  # a reconnect left it un-joined
+    channel._rejoin = AsyncMock()
+
+    expiry_state = {"unix": relay.time.time() - 1000}
+
+    async def _run():
+        await asyncio.wait_for(
+            relay._jwt_refresher(rt_client, channel, weco_client, "sess-1", expiry_state, stop_event), timeout=3.0
+        )
+
+    asyncio.run(_run())
+    rt_client.set_auth.assert_awaited_once_with("T2")
+    channel.join_push.update_payload.assert_called_once_with({"access_token": "T2"})
+    channel._rejoin.assert_awaited_once()

--- a/tests/test_start_session.py
+++ b/tests/test_start_session.py
@@ -100,3 +100,21 @@ def test_weco_client_close_session_patches_status():
     url = patch_call.call_args.args[0]
     assert url.endswith("/sessions/sess-1")
     assert patch_call.call_args.kwargs["json"] == {"status": "closed"}
+
+
+def test_refresh_realtime_token_raises_on_409():
+    from weco.core.api import SessionInactiveError, WecoClient
+
+    client = WecoClient({"Authorization": "Bearer weco-k"})
+    with patch.object(client._session, "post", return_value=MagicMock(status_code=409)):
+        with pytest.raises(SessionInactiveError):
+            client.refresh_realtime_token("sess-1")
+
+
+def test_session_heartbeat_raises_on_409():
+    from weco.core.api import SessionInactiveError, WecoClient
+
+    client = WecoClient({"Authorization": "Bearer weco-k"})
+    with patch.object(client._session, "post", return_value=MagicMock(status_code=409)):
+        with pytest.raises(SessionInactiveError):
+            client.session_heartbeat("sess-1")

--- a/weco/commands/start/cli.py
+++ b/weco/commands/start/cli.py
@@ -42,6 +42,27 @@ def configure_start_parser(start_parser: argparse.ArgumentParser) -> None:
         ),
     )
     claude_parser.add_argument(
+        "--headless",
+        action="store_true",
+        help=(
+            "Run with no local TUI — stream only to the dashboard, printing key "
+            "lifecycle lines to the console. Use when launching in the background "
+            "(no terminal to draw into), e.g. an agent spawning a bridged session. "
+            "Pair with --allow-tools (no local approval modal) and --prompt to seed "
+            "the first turn; the dashboard is the interactive surface."
+        ),
+    )
+    claude_parser.add_argument(
+        "-p",
+        "--prompt",
+        type=str,
+        default=None,
+        help=(
+            "Seed the first turn with this prompt instead of waiting for input. "
+            "Required to make --headless do anything immediately; also works in the TUI."
+        ),
+    )
+    claude_parser.add_argument(
         "--billing",
         type=str,
         choices=["claude", "weco"],
@@ -107,11 +128,20 @@ def _handle_claude(args: argparse.Namespace, console: Console) -> None:
 
     effort = getattr(args, "effort", None)
     billing = getattr(args, "billing", "claude")
+    headless = getattr(args, "headless", False)
+    seed_prompt = getattr(args, "prompt", None)
 
     from weco import __base_url__
-    from .tui_bridge import run_tui_bridge
+    from .tui_bridge import run_headless_bridge, run_tui_bridge
 
-    exit_code = run_tui_bridge(
-        claude_args=forwarded, api_key=api_key, console=console, billing=billing, weco_api_base=__base_url__, effort=effort
+    runner = run_headless_bridge if headless else run_tui_bridge
+    exit_code = runner(
+        claude_args=forwarded,
+        api_key=api_key,
+        console=console,
+        billing=billing,
+        weco_api_base=__base_url__,
+        effort=effort,
+        seed_prompt=seed_prompt,
     )
     sys.exit(exit_code)

--- a/weco/commands/start/relay.py
+++ b/weco/commands/start/relay.py
@@ -39,6 +39,8 @@ from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from typing import TYPE_CHECKING, Awaitable, Callable, Iterator, Optional, TextIO
 
+from weco.core.api import SessionInactiveError
+
 if TYPE_CHECKING:
     from weco.core.api import WecoClient
 
@@ -331,7 +333,7 @@ async def run_channel(
         return
 
     publisher = asyncio.create_task(_publisher_loop(channel, outbound, scrollback, seq_counter, local_log, stop_event))
-    refresher = asyncio.create_task(_jwt_refresher(client, weco_client, session_id, expiry_state, stop_event))
+    refresher = asyncio.create_task(_jwt_refresher(client, channel, weco_client, session_id, expiry_state, stop_event))
     heartbeater = asyncio.create_task(_heartbeat_loop(weco_client, session_id, stop_event))
 
     try:
@@ -468,12 +470,19 @@ async def _heartbeat_loop(weco_client: "WecoClient", session_id: str, stop_event
 
         try:
             await asyncio.to_thread(weco_client.session_heartbeat, session_id)
+        except SessionInactiveError:
+            # Session is gone for good (closed, or expired past the revive
+            # grace). Tear the bridge down instead of pinging a dead session
+            # forever — the supervisor cancels the sibling loops on stop.
+            logger.info("session %s is no longer active; stopping dashboard bridge", session_id)
+            stop_event.set()
+            return
         except Exception as e:
             logger.info("heartbeat failed for session %s: %s", session_id, e)
 
 
 async def _jwt_refresher(
-    rt_client, weco_client: "WecoClient", session_id: str, expiry_state: dict, stop_event: asyncio.Event
+    rt_client, channel, weco_client: "WecoClient", session_id: str, expiry_state: dict, stop_event: asyncio.Event
 ) -> None:
     """Mint a new JWT before the current one expires; push it into the channel."""
     while not stop_event.is_set():
@@ -487,6 +496,13 @@ async def _jwt_refresher(
 
         try:
             fresh = await asyncio.to_thread(weco_client.refresh_realtime_token, session_id)
+        except SessionInactiveError:
+            # Session is gone for good (closed, or expired past the revive
+            # grace) — minting will never succeed again. Stop the bridge rather
+            # than 409-storm the endpoint every 5s until the user Ctrl-Cs.
+            logger.info("session %s is no longer active; stopping dashboard bridge", session_id)
+            stop_event.set()
+            return
         except Exception as e:
             logger.warning("JWT refresh failed for session %s: %s", session_id, e)
             # Back off and retry; if expiry has passed the channel will drop and
@@ -499,5 +515,24 @@ async def _jwt_refresher(
         except Exception as e:
             logger.warning("set_auth failed for session %s: %s", session_id, e)
             continue
+
+        # Keep the channel's *join* payload token current. realtime-py bakes the
+        # access_token into the join push once at subscribe() time and reuses it
+        # verbatim on every reconnect rejoin (join_push.resend); set_auth updates
+        # live channels but NOT that baked payload. So after a reconnect that
+        # outlives the original 60-min JWT — now common inside the 2h revive
+        # grace — the channel would rejoin with a dead token, authorization
+        # fails, and inbound broadcasts (dashboard -> CLI) silently stop while
+        # outbound still limps through (push() only checks _joined_once, not the
+        # real join state). Re-stamping here means any future rejoin carries a
+        # live token; forcing a rejoin when we're not currently joined recovers a
+        # channel a reconnect already broke, promptly rather than on the rejoin
+        # timer's backoff.
+        try:
+            channel.join_push.update_payload({"access_token": fresh["token"]})
+            if not channel.is_joined:
+                await channel._rejoin()
+        except Exception as e:
+            logger.warning("channel rejoin after token refresh failed for session %s: %s", session_id, e)
 
         expiry_state["unix"] = _parse_iso(fresh["expires_at"])

--- a/weco/commands/start/tui_bridge.py
+++ b/weco/commands/start/tui_bridge.py
@@ -101,6 +101,7 @@ def run_tui_bridge(
     billing: str = "claude",
     weco_api_base: Optional[str] = None,
     effort: Optional[str] = None,
+    seed_prompt: Optional[str] = None,
 ) -> int:
     """Boot the TUI and the SDK-driven orchestrator."""
     try:
@@ -119,6 +120,7 @@ def run_tui_bridge(
         billing=billing,
         weco_api_base=weco_api_base,
         effort=effort,
+        seed_prompt=seed_prompt,
     )
 
     app.set_submit_callback(orchestrator.on_user_submit)
@@ -128,6 +130,138 @@ def run_tui_bridge(
 
     app.run()
     return orchestrator.exit_code
+
+
+def run_headless_bridge(
+    *,
+    claude_args: list[str],
+    api_key: str,
+    console: Console,
+    billing: str = "claude",
+    weco_api_base: Optional[str] = None,
+    effort: Optional[str] = None,
+    seed_prompt: Optional[str] = None,
+) -> int:
+    """Run the SDK-driven orchestrator with NO local TUI — the bridge streams to
+    the dashboard and key lifecycle lines print to the console. This is the mode
+    an agent launches in the background (`weco start claude --headless`): there's
+    no terminal to draw a Textual app into, so the dashboard is the only
+    interactive surface. Pair with `--allow-tools` (no local approval modal) and
+    `--prompt` to seed the first turn."""
+    try:
+        session = DashboardSession.create(api_key=api_key, agent_type=AGENT_TYPE)
+    except SetupError as e:
+        console.print(f"[red]Could not create dashboard session:[/] {e}")
+        console.print(
+            "[yellow]Headless mode relies on the dashboard relay for interactivity — continuing offline; "
+            "the session will only run the seeded prompt.[/]"
+        )
+        session = DashboardSession.offline()
+
+    app = HeadlessUI(console)
+    orchestrator = Orchestrator(
+        app=app,
+        claude_args=claude_args,
+        api_key=api_key,
+        session=session,
+        billing=billing,
+        weco_api_base=weco_api_base,
+        effort=effort,
+        seed_prompt=seed_prompt,
+    )
+
+    if orchestrator.dashboard_url:
+        console.print(f"[green]Bridged session live.[/] Watch and steer at: [bold]{orchestrator.dashboard_url}[/]")
+
+    try:
+        asyncio.run(orchestrator.run_until_stopped())
+    except KeyboardInterrupt:
+        pass
+    return orchestrator.exit_code
+
+
+# ---------------------------------------------------------------------------
+# HeadlessUI — a no-TTY stand-in for WecoTUI used by `--headless`.
+# ---------------------------------------------------------------------------
+
+
+class HeadlessUI:
+    """Duck-typed replacement for ``WecoTUI`` when there's no terminal to draw
+    into. The dashboard relay carries the full interactive transcript; here we
+    just print a readable lifecycle log to the console (banner, system notices,
+    tool calls, run updates) so a backgrounded session leaves a useful trail.
+
+    Everything visual — token-stream deltas, the thinking spinner, inline
+    approval/question cards — is a no-op, supplied by ``__getattr__`` so the
+    Orchestrator and Renderer can call the full WecoTUI surface unchanged. With
+    ``--allow-tools`` the SDK bypasses approvals, so the cards never fire; without
+    it, ``mount_inline_card`` no-ops locally and the dashboard resolves them."""
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+
+    def post_banner(
+        self,
+        *,
+        agent: str = "Claude Code",
+        model: Optional[str] = None,
+        billing: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        bits = [agent]
+        if model:
+            bits.append(f"model={model}")
+        if billing:
+            bits.append(f"billing={billing}")
+        if session_id:
+            bits.append(f"session={session_id}")
+        self._console.print(f"[bold cyan]{' · '.join(bits)}[/]")
+
+    def post_system_notice(self, text: str, *, style: str = "dim italic") -> None:
+        self._console.print(text, style=style, markup=False, highlight=False)
+
+    def post_user_message(self, text: str) -> None:
+        self._console.print(f"› {text}", style="dim", markup=False, highlight=False)
+
+    def post_tool_use(self, tool_id: str, name: str, summary: str, tool_input: dict) -> None:
+        line = f"[tool] {name}" + (f" — {summary}" if summary else "")
+        self._console.print(line, style="dim", markup=False, highlight=False)
+
+    def post_run_update(self, update: dict) -> None:
+        if not isinstance(update, dict):
+            return
+        rid = str(update.get("run_id", "") or "")
+        parts = [f"run {rid[:8]}"] if rid else ["run"]
+        status = update.get("status")
+        if status:
+            parts.append(str(status))
+        step = update.get("step", update.get("current_step"))
+        if step is not None:
+            total = update.get("total_steps")
+            parts.append(f"step {step}" + (f"/{total}" if total else ""))
+        best = update.get("best_metric")
+        if best is not None:
+            parts.append(f"best={best}")
+        self._console.print("● " + " · ".join(parts), style="cyan", markup=False, highlight=False)
+
+    def post_turn_end(self, subtype: str, *, cost: Optional[float] = None, duration_ms: Optional[int] = None) -> None:
+        suffix = f" (${cost:.4f} api equiv)" if isinstance(cost, (int, float)) else ""
+        style = "dim" if subtype == "success" else "bold yellow"
+        self._console.print(f"— {subtype}{suffix} —", style=style, markup=False, highlight=False)
+
+    def mount_inline_card(self, card: Any) -> None:
+        # No local surface — leave the approval/question card unresolved for the
+        # dashboard to answer. (With --allow-tools the SDK never asks.)
+        return
+
+    def exit(self) -> None:
+        return
+
+    def __getattr__(self, _name: str) -> Callable[..., None]:
+        # Everything else WecoTUI exposes (post_assistant_delta, show_thinking,
+        # hide_thinking, end_assistant_block, post_tool_result, …) is a visual
+        # no-op without a terminal.
+        return lambda *a, **k: None
 
 
 # ---------------------------------------------------------------------------
@@ -146,6 +280,7 @@ class Orchestrator:
         billing: str,
         weco_api_base: Optional[str],
         effort: Optional[str],
+        seed_prompt: Optional[str] = None,
     ) -> None:
         self.app = app
         self.claude_args = claude_args
@@ -154,6 +289,10 @@ class Orchestrator:
         self.billing = billing
         self.weco_api_base = weco_api_base
         self.effort = effort
+        # Optional first-turn prompt (from `--prompt`). Enqueued once the SDK
+        # client is connected so it drives the session without a typed input —
+        # required for headless launches, handy for the TUI.
+        self._seed_prompt = seed_prompt
 
         self.session_id: Optional[str] = session.id
         self.dashboard_url: Optional[str] = session.dashboard_url
@@ -209,16 +348,27 @@ class Orchestrator:
 
     # --- App startup callback -------------------------------------------
 
-    def run(self) -> None:
-        """Top-level startup callback. Scheduled by WecoTUI once the app
-        is mounted. Post the banner first so it's visible before any async
-        lifecycle work, then kick off the orchestrator."""
+    def _post_banner(self) -> None:
         self.app.post_banner(
             agent="Claude Code", model=resolve_model(self.claude_args), billing=self.billing, session_id=self.session_id
         )
         if not self.dashboard_url:
             self.app.post_system_notice("Running without dashboard relay.", style="dim yellow")
+
+    def run(self) -> None:
+        """Top-level startup callback. Scheduled by WecoTUI once the app
+        is mounted. Post the banner first so it's visible before any async
+        lifecycle work, then kick off the orchestrator."""
+        self._post_banner()
         asyncio.create_task(self._run())
+
+    async def run_until_stopped(self) -> None:
+        """Headless entry point. Posts the banner, then runs the full lifecycle
+        to completion (blocks until the session stops). The TUI path uses the
+        sync `run()` startup callback instead, which schedules `_run()` as a task
+        inside Textual's own event loop."""
+        self._post_banner()
+        await self._run()
 
     async def _run(self) -> None:
         try:
@@ -284,6 +434,10 @@ class Orchestrator:
         # background-task completions, scheduled wakeups) from being stranded in
         # the transport until the next prompt drains it.
         self._tasks.append(asyncio.create_task(self._consume_messages()))
+        # Seed the first turn (from `--prompt`) now that the consumer is live and
+        # the SDK is connected. The pump drains it on its first iteration.
+        if self._seed_prompt:
+            await self._pending_prompts.put((self._seed_prompt, None, True))
         await self._prompt_pump()
 
     def _build_options(self) -> ClaudeAgentOptions:

--- a/weco/core/api.py
+++ b/weco/core/api.py
@@ -15,6 +15,22 @@ from ..constants import TRUNCATION_THRESHOLD, TRUNCATION_KEEP_LENGTH
 
 
 # ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class SessionInactiveError(Exception):
+    """A dashboard session is no longer revivable (HTTP 409).
+
+    Raised by the session liveness calls (``session_heartbeat`` /
+    ``refresh_realtime_token``) when the server reports the session is
+    deliberately closed or expired past its revive grace window. It's terminal:
+    the caller should stop the bridge rather than retry, since no amount of
+    retrying will bring the session back.
+    """
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -187,14 +203,26 @@ class WecoClient:
         return resp.json()
 
     def refresh_realtime_token(self, session_id: str) -> dict:
-        """Mint a fresh Realtime JWT for an existing session."""
+        """Mint a fresh Realtime JWT for an existing session.
+
+        Raises ``SessionInactiveError`` on HTTP 409 — the session is no longer
+        revivable (deliberately closed, or expired past the server's grace
+        window) — so the caller stops rather than retrying a dead session.
+        """
         resp = self._post(f"/sessions/{session_id}/realtime-token", timeout=(5, 30))
+        if resp.status_code == 409:
+            raise SessionInactiveError(session_id)
         resp.raise_for_status()
         return resp.json()
 
     def session_heartbeat(self, session_id: str) -> None:
-        """Roll the session's `expires_at` forward. Best-effort — caller swallows."""
-        self._post(f"/sessions/{session_id}/heartbeat", timeout=(5, 10))
+        """Roll the session's `expires_at` forward (reviving it if the server is
+        still within its grace window). Best-effort for transient failures — the
+        caller swallows those — but raises ``SessionInactiveError`` on HTTP 409
+        so a bridge whose session is permanently gone can stop."""
+        resp = self._post(f"/sessions/{session_id}/heartbeat", timeout=(5, 10))
+        if resp.status_code == 409:
+            raise SessionInactiveError(session_id)
 
     def close_session(self, session_id: str) -> None:
         """Mark the session closed so the dashboard updates without waiting for TTL."""
@@ -385,6 +413,14 @@ class WecoClient:
         ``last_step + steps`` and produces the next candidate. Required for
         runs already in the ``completed`` state.
 
+        Uses the long read timeout (``(10, 3650)``, same as ``/suggest`` and
+        run creation) because resume can run server-side LLM candidate
+        generation (``_resume_generate_candidate_if_needed``): for a completed
+        run, or any run with no runnable work, the backend blocks the response
+        on a full generation that routinely exceeds 10s. A short read timeout
+        here makes the CLI abort while the backend keeps going, leaving the run
+        ``running`` with an unclaimed task that then dies of heartbeat timeout.
+
         Raises:
             requests.exceptions.HTTPError: On non-2xx responses.
         """
@@ -393,7 +429,7 @@ class WecoClient:
             body["api_keys"] = api_keys
         if steps is not None:
             body["steps"] = steps
-        resp = self._post(f"/runs/{run_id}/resume", json=body, timeout=(5, 10))
+        resp = self._post(f"/runs/{run_id}/resume", json=body, timeout=(10, 3650))
         resp.raise_for_status()
         return resp.json()
 


### PR DESCRIPTION
## Graceful session reconnection

  ### Problem
  A bridged session is kept alive by the CLI heartbeat (2-min TTL; a backend sweeper flips it to
  `expired` once pings stop). Previously, expiry was terminal, and the relay's JWT-refresh and
  heartbeat loops treated the resulting `409`s as transient — retrying every ~5s forever. A laptop
  that slept with `weco start` running would 409-storm the API until the user `Ctrl-C`'d.
  Separately, when a session *did* come back, **dashboard→CLI control messages silently stopped**
  while CLI→dashboard transcript kept flowing.

  ### Changes
  - **Stop storming on terminal `409`.** `WecoClient.refresh_realtime_token` / `session_heartbeat`
  now raise `SessionInactiveError` on `409`. The relay's `_jwt_refresher` and `_heartbeat_loop`
  catch it and tear the bridge down cleanly (the supervisor cancels sibling loops and closes the      session) instead of retrying a permanently-dead session. Transient 5xx/network errors still retry
  as before.
  - **Restore inbound after a long reconnect.** `realtime-py` bakes the access token into the         channel join payload once at `subscribe()` and reuses it verbatim on every reconnect rejoin;
  `set_auth()` never updates that baked payload. So a reconnect outliving the original 60-min JWT
  (now common within the 2h revive grace) rejoined with a dead token → private-channel auth failed →  inbound broadcasts dropped, while outbound limped on (`push()` only checks `_joined_once`, not
  real join state). The JWT refresher now re-stamps the join payload with the fresh token and forces
  a prompt rejoin when the channel isn't joined, so inbound recovers within ~1s of waking.
  ### Behaviour

  | Scenario | Before | After |
  |---|---|---|                                                                                       | Disconnect < 2 min | Stays alive | Stays alive |
  | Disconnect within grace (≤ 2h) | Session dead; CLI 409-storms until `Ctrl-C` | Session            **revives**; bridge keeps streaming on the same session/channel |
  | Reconnect after JWT expiry (> 60 min) | Outbound only; **dashboard→CLI dead** | Both directions
  restored |
  | Disconnect past grace / closed from dashboard | 409-storm forever | Bridge stops cleanly (local
  agent keeps running) |