### PR TITLE
Merge Dev - Lineage-wide run inspection in the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "weco"
 authors = [{ name = "Weco AI Team", email = "contact@weco.ai" }]
 description = "Documentation for `weco`, a CLI for using Weco AI's code optimizer."
 readme = "README.md"
-version = "0.3.37"
+version = "0.3.38"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [

--- a/weco/cli.py
+++ b/weco/cli.py
@@ -215,6 +215,19 @@ def _configure_run_subcommands(run_parser: argparse.ArgumentParser) -> None:
     # weco run status <run-id>
     p = subs.add_parser("status", help="Show run status and progress (JSON)")
     p.add_argument("run_id", type=str, help="Run UUID")
+    p.add_argument(
+        "--lineage",
+        action="store_true",
+        help="Report lineage-wide aggregates (status, best, steps) across all derived runs, not just this run.",
+    )
+
+    # weco run overview <run-id>
+    p = subs.add_parser(
+        "overview", help="Show the full lineage picture (tree, global best, all derived runs) — dashboard parity"
+    )
+    p.add_argument("run_id", type=str, help="Any run UUID in the lineage")
+    p.add_argument("--include-code", action="store_true", help="Include plan and full source code for each node")
+    p.add_argument("--plot", action="store_true", help="Show ASCII metric trajectory across the whole lineage")
 
     # weco run results <run-id>
     p = subs.add_parser("results", help="Show results sorted by metric")
@@ -223,16 +236,26 @@ def _configure_run_subcommands(run_parser: argparse.ArgumentParser) -> None:
     p.add_argument("--format", type=str, choices=["json", "table", "csv"], default="json", help="Output format")
     p.add_argument("--plot", action="store_true", help="Show ASCII metric trajectory")
     p.add_argument("--include-code", action="store_true", help="Include full source code")
+    p.add_argument(
+        "--lineage", action="store_true", help="Rank results across all derived runs in the lineage, not just this run."
+    )
 
     # weco run show <run-id> --step N
     p = subs.add_parser("show", help="Show details for a specific step")
     p.add_argument("run_id", type=str, help="Run UUID")
-    p.add_argument("--step", type=str, required=True, help="Step number or 'best'")
+    p.add_argument(
+        "--step",
+        type=str,
+        required=True,
+        help="Step number, 'best' (lineage-best, matches `derive --from-step best`), or 'run-best' (best in this run)",
+    )
 
     # weco run diff <run-id> --step N
     p = subs.add_parser("diff", help="Show code diff between steps")
     p.add_argument("run_id", type=str, help="Run UUID")
-    p.add_argument("--step", type=str, required=True, help="Step number or 'best'")
+    p.add_argument(
+        "--step", type=str, required=True, help="Step number, 'best' (lineage-best), or 'run-best' (best in this run)"
+    )
     p.add_argument("--against", type=str, default="baseline", help="'baseline' (default), 'parent', or step number")
 
     # weco run stop <run-id>
@@ -453,7 +476,7 @@ Supported provider names: {supported_providers}.
 
 def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
     """Dispatch ``weco run <subcommand>`` to the appropriate handler."""
-    from .commands.run import status, results, show, diff, stop, instruct, review, revise, submit, derive
+    from .commands.run import status, overview, results, show, diff, stop, instruct, review, revise, submit, derive
 
     def _collect_source_paths() -> list[str] | None:
         if getattr(args, "sources", None):
@@ -463,13 +486,17 @@ def _dispatch_run_subcommand(sub: str, args: argparse.Namespace) -> None:
         return None
 
     handlers = {
-        "status": lambda: status.handle(run_id=args.run_id, console=console),
+        "status": lambda: status.handle(run_id=args.run_id, lineage=args.lineage, console=console),
+        "overview": lambda: overview.handle(
+            run_id=args.run_id, include_code=args.include_code, plot=args.plot, console=console
+        ),
         "results": lambda: results.handle(
             run_id=args.run_id,
             top=args.top,
             format=args.format,
             plot=args.plot,
             include_code=args.include_code,
+            lineage=args.lineage,
             console=console,
         ),
         "show": lambda: show.handle(run_id=args.run_id, step=args.step, console=console),

--- a/weco/commands/__init__.py
+++ b/weco/commands/__init__.py
@@ -27,6 +27,36 @@ def fetch_run(client: WecoClient, run_id: str, include_history: bool = True) -> 
         sys.exit(1)
 
 
+def resolve_lineage_id(client: WecoClient, run_id: str) -> str:
+    """Resolve a run ID to its lineage ID (= root run ID).
+
+    A standalone (non-derived) run has no ``lineage_id`` of its own — it *is*
+    the lineage root, so we fall back to the run ID. Exits on fetch error.
+    """
+    run = fetch_run(client, run_id, include_history=False)
+    return run.get("lineage_id") or run_id
+
+
+def fetch_lineage(client: WecoClient, lineage_id: str) -> dict:
+    """Fetch the full lineage tree via ``GET /lineages/{id}``, or exit on error."""
+    try:
+        return client.get_lineage(lineage_id)
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to fetch lineage {lineage_id}: {e}"}))
+        sys.exit(1)
+
+
+def fetch_lineage_nodes(
+    client: WecoClient, lineage_id: str, *, include_details: bool = False, status: str | None = None
+) -> list[dict]:
+    """Fetch all nodes across a lineage via ``GET /lineages/{id}/nodes``, or exit."""
+    try:
+        return client.list_lineage_nodes(lineage_id, include_details=include_details, status=status).get("nodes", [])
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to fetch lineage nodes for {lineage_id}: {e}"}))
+        sys.exit(1)
+
+
 def fetch_nodes(
     client: WecoClient,
     run_id: str,

--- a/weco/commands/run/diff.py
+++ b/weco/commands/run/diff.py
@@ -6,7 +6,7 @@ import sys
 
 from rich.console import Console
 
-from .. import make_client, fetch_nodes
+from .. import make_client, fetch_nodes, resolve_lineage_id, fetch_lineage
 
 
 def _get_node_by_step(client, run_id: str, step: int, include_code: bool = True) -> dict | None:
@@ -15,19 +15,40 @@ def _get_node_by_step(client, run_id: str, step: int, include_code: bool = True)
     return nodes[0] if nodes else None
 
 
-def _get_best_node(client, run_id: str) -> dict | None:
-    """Fetch the best-scoring node."""
+def _get_run_best_node(client, run_id: str) -> dict | None:
+    """Fetch the best-scoring node within a single run."""
     _meta, nodes = fetch_nodes(client, run_id, sort="metric", top=1)
     return nodes[0] if nodes else None
+
+
+def _get_lineage_best_node(client, run_id: str) -> tuple[dict | None, str | None]:
+    """Resolve the lineage-global best node and the run that owns it — the same
+    node `derive --from-step best` branches from."""
+    lineage_id = resolve_lineage_id(client, run_id)
+    best = fetch_lineage(client, lineage_id).get("best")
+    if not best:
+        return None, None
+    best_run_id = best.get("run_id")
+    return _get_node_by_step(client, best_run_id, best.get("step")), best_run_id
 
 
 def handle(run_id: str, step: str, against: str, console: Console) -> None:
     """Show code diff between steps."""
     client = make_client(console)
 
+    # The run whose nodes we diff against. For lineage-best this may differ from
+    # the queried run, so baseline/parent/step comparisons resolve within the
+    # run that actually owns the best node.
+    base_run_id = run_id
+
     # Resolve target node
     if step == "best":
-        target_node = _get_best_node(client, run_id)
+        target_node, base_run_id = _get_lineage_best_node(client, run_id)
+        if not target_node:
+            print(json.dumps({"error": "No scored nodes found in lineage"}))
+            sys.exit(1)
+    elif step == "run-best":
+        target_node = _get_run_best_node(client, run_id)
         if not target_node:
             print(json.dumps({"error": "No scored nodes found"}))
             sys.exit(1)
@@ -35,7 +56,7 @@ def handle(run_id: str, step: str, against: str, console: Console) -> None:
         try:
             step_num = int(step)
         except ValueError:
-            print(json.dumps({"error": f"Invalid step: {step}. Use an integer or 'best'"}))
+            print(json.dumps({"error": f"Invalid step: {step}. Use an integer, 'best', or 'run-best'"}))
             sys.exit(1)
         target_node = _get_node_by_step(client, run_id, step_num)
         if not target_node:
@@ -46,7 +67,7 @@ def handle(run_id: str, step: str, against: str, console: Console) -> None:
 
     # Resolve base node
     if against == "baseline":
-        base_node = _get_node_by_step(client, run_id, 0)
+        base_node = _get_node_by_step(client, base_run_id, 0)
         if not base_node:
             print(json.dumps({"error": "No baseline node (step 0) found"}))
             sys.exit(1)
@@ -56,7 +77,7 @@ def handle(run_id: str, step: str, against: str, console: Console) -> None:
         if parent_step is None:
             print(json.dumps({"error": f"Node at step {target_node.get('step')} has no parent"}))
             sys.exit(1)
-        base_node = _get_node_by_step(client, run_id, parent_step)
+        base_node = _get_node_by_step(client, base_run_id, parent_step)
         if not base_node:
             print(json.dumps({"error": f"Parent node at step {parent_step} not found"}))
             sys.exit(1)
@@ -67,7 +88,7 @@ def handle(run_id: str, step: str, against: str, console: Console) -> None:
         except ValueError:
             print(json.dumps({"error": f"Invalid --against value: {against}. Use 'baseline', 'parent', or a step number"}))
             sys.exit(1)
-        base_node = _get_node_by_step(client, run_id, base_step)
+        base_node = _get_node_by_step(client, base_run_id, base_step)
         if not base_node:
             print(json.dumps({"error": f"No node found at step {base_step}"}))
             sys.exit(1)

--- a/weco/commands/run/overview.py
+++ b/weco/commands/run/overview.py
@@ -84,7 +84,7 @@ def handle(run_id: str, include_code: bool, plot: bool, console: Console) -> Non
         # Lineage-wide trajectory in global-step order, scored nodes only.
         scored = sorted(
             (n for n in nodes if n.get("metric_value") is not None),
-            key=lambda n: (n.get("global_step") if n.get("global_step") is not None else 0),
+            key=lambda n: n.get("global_step") if n.get("global_step") is not None else 0,
         )
         if scored:
             values = [n["metric_value"] for n in scored]

--- a/weco/commands/run/overview.py
+++ b/weco/commands/run/overview.py
@@ -1,0 +1,98 @@
+"""``weco run overview <run-id>`` — lineage-wide run picture (dashboard parity).
+
+The other read commands (``status``, ``results``, ``show``, ``diff``) are
+single-run scoped. Once a run has been ``derive``d, the related runs form a
+*lineage* — a tree of root + derived branches — and a per-run view can't show
+the global best, the derived branches, or where each branched. This command
+resolves a run to its lineage and returns the whole picture in one call,
+matching what the dashboard run page shows.
+"""
+
+import json
+
+from rich.console import Console
+
+from .. import make_client, resolve_lineage_id, fetch_lineage, fetch_lineage_nodes
+from .results import _sparkline
+
+
+def handle(run_id: str, include_code: bool, plot: bool, console: Console) -> None:
+    """Show the full lineage overview for the run as JSON."""
+    client = make_client(console)
+
+    lineage_id = resolve_lineage_id(client, run_id)
+    lineage = fetch_lineage(client, lineage_id)
+    nodes = fetch_lineage_nodes(client, lineage_id, include_details=include_code)
+
+    best = lineage.get("best")
+    members = []
+    for m in lineage.get("members", []):
+        members.append(
+            {
+                "run_id": m.get("id"),
+                "name": m.get("name"),
+                "status": m.get("status"),
+                "sub_run_index": m.get("sub_run_index"),
+                "best_metric": m.get("best_metric"),
+                "best_step": m.get("best_step"),
+                "current_step": m.get("current_step"),
+                "steps": m.get("steps"),
+                "derived_from": m.get("derived_from"),
+                "additional_instructions": m.get("additional_instructions"),
+                "children": m.get("children", []),
+            }
+        )
+
+    node_list = []
+    for n in nodes:
+        entry = {
+            "global_step": n.get("global_step"),
+            "run_id": n.get("run_id"),
+            "step": n.get("step"),
+            "node_id": n.get("id"),
+            "parent_id": n.get("parent_id"),
+            "metric": n.get("metric_value"),
+            "status": n.get("status"),
+            "is_buggy": n.get("is_buggy"),
+            "summary_title": n.get("summary_title"),
+        }
+        if include_code:
+            entry["plan"] = n.get("plan", "")
+            entry["code"] = n.get("code", {})
+        node_list.append(entry)
+
+    output = {
+        "lineage_id": lineage.get("id", lineage_id),
+        "root_run_id": lineage.get("root_run_id"),
+        "name": lineage.get("name"),
+        "metric_name": lineage.get("metric_name"),
+        "goal": "maximize" if lineage.get("maximize") else "minimize",
+        "status": lineage.get("status"),
+        "best_metric": lineage.get("best_metric"),
+        "current_step": lineage.get("current_step"),
+        "total_steps": lineage.get("total_steps"),
+        "member_count": lineage.get("member_count"),
+        "active_member_count": lineage.get("active_member_count"),
+        "best": best,
+        "members": members,
+        "nodes": node_list,
+    }
+
+    print(json.dumps(output, indent=2))
+
+    if plot:
+        # Lineage-wide trajectory in global-step order, scored nodes only.
+        scored = sorted(
+            (n for n in nodes if n.get("metric_value") is not None),
+            key=lambda n: (n.get("global_step") if n.get("global_step") is not None else 0),
+        )
+        if scored:
+            values = [n["metric_value"] for n in scored]
+            best_val = lineage.get("best_metric", values[0])
+            best_step = best.get("step") if best else "?"
+            best_run = best.get("run_id") if best else "?"
+            spark = _sparkline(values)
+            print(
+                f"\nLineage steps 0-{len(scored)}: {values[0]:.4g} {spark} -> "
+                f"{best_val:.4g} (best at step {best_step} in run {best_run})"
+            )

--- a/weco/commands/run/results.py
+++ b/weco/commands/run/results.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from rich.console import Console
 
-from .. import make_client, fetch_nodes
+from .. import make_client, fetch_nodes, resolve_lineage_id, fetch_lineage, fetch_lineage_nodes
 
 
 def _sparkline(values: list[float], width: int = 30) -> str:
@@ -23,7 +23,44 @@ def _sparkline(values: list[float], width: int = 30) -> str:
     return "".join(blocks[min(int((v - lo) / spread * (len(blocks) - 1)), len(blocks) - 1)] for v in sampled)
 
 
-def handle(run_id: str, top: Optional[int], format: str, plot: bool, include_code: bool, console: Console) -> None:
+def _lineage_results(client, run_id: str, top: Optional[int], include_code: bool) -> tuple[dict, list[dict]]:
+    """Fetch lineage-wide nodes ranked by metric, normalised to the per-run node shape.
+
+    Each node also carries ``global_step`` and ``run_id`` so the lineage view can
+    show where in the tree a result came from.
+    """
+    lineage_id = resolve_lineage_id(client, run_id)
+    lineage = fetch_lineage(client, lineage_id)
+    raw = fetch_lineage_nodes(client, lineage_id, include_details=include_code)
+
+    scored = [n for n in raw if n.get("metric_value") is not None]
+    scored.sort(key=lambda n: n["metric_value"], reverse=bool(lineage.get("maximize")))
+    if top is not None:
+        scored = scored[:top]
+
+    nodes = [
+        {
+            "step": n.get("step"),
+            "global_step": n.get("global_step"),
+            "run_id": n.get("run_id"),
+            "metric_value": n.get("metric_value"),
+            "plan": n.get("plan", ""),
+            "node_id": n.get("id"),
+            "code": n.get("code", {}),
+        }
+        for n in scored
+    ]
+    run_meta = {
+        "metric_name": lineage.get("metric_name", "metric"),
+        "best_metric": lineage.get("best_metric"),
+        "best_step": (lineage.get("best") or {}).get("step"),
+    }
+    return run_meta, nodes
+
+
+def handle(
+    run_id: str, top: Optional[int], format: str, plot: bool, include_code: bool, lineage: bool, console: Console
+) -> None:
     """Show run results sorted by metric."""
     client = make_client(console)
 
@@ -31,7 +68,10 @@ def handle(run_id: str, top: Optional[int], format: str, plot: bool, include_cod
         print(json.dumps([]))
         return
 
-    run_meta, nodes = fetch_nodes(client, run_id, top=top, sort="metric", include_code=include_code)
+    if lineage:
+        run_meta, nodes = _lineage_results(client, run_id, top, include_code)
+    else:
+        run_meta, nodes = fetch_nodes(client, run_id, top=top, sort="metric", include_code=include_code)
     metric_name = run_meta.get("metric_name", "metric")
 
     if format == "json":
@@ -43,35 +83,59 @@ def handle(run_id: str, top: Optional[int], format: str, plot: bool, include_cod
                 "plan": n.get("plan", ""),
                 "node_id": n.get("node_id"),
             }
+            if lineage:
+                entry["global_step"] = n.get("global_step")
+                entry["run_id"] = n.get("run_id")
             if include_code:
                 entry["code"] = n.get("code", {})
             results.append(entry)
         print(json.dumps(results, indent=2))
 
     elif format == "table":
-        header = f"{'Step':>6}  {'Metric':>12}  Plan"
+        if lineage:
+            header = f"{'Global':>6}  {'Run:Step':>14}  {'Metric':>12}  Plan"
+        else:
+            header = f"{'Step':>6}  {'Metric':>12}  Plan"
         print(header)
         print("-" * len(header))
         for n in nodes:
-            step = n.get("step", "?")
             metric = n.get("metric_value")
             metric_str = f"{metric:.6g}" if metric is not None else "N/A"
             plan = (n.get("plan") or "")[:80]
-            print(f"{step:>6}  {metric_str:>12}  {plan}")
+            if lineage:
+                gstep = n.get("global_step")
+                gstr = str(gstep) if gstep is not None else "?"
+                coord = f"{(n.get('run_id') or '')[:8]}:{n.get('step', '?')}"
+                print(f"{gstr:>6}  {coord:>14}  {metric_str:>12}  {plan}")
+            else:
+                print(f"{n.get('step', '?'):>6}  {metric_str:>12}  {plan}")
 
     elif format == "csv":
-        print(f"step,{metric_name},plan,node_id")
-        for n in nodes:
-            step = n.get("step", "")
-            metric = n.get("metric_value", "")
-            plan = (n.get("plan") or "").replace('"', '""')
-            nid = n.get("node_id", "")
-            print(f'{step},{metric},"{plan}",{nid}')
+        if lineage:
+            print(f"global_step,run_id,step,{metric_name},plan,node_id")
+            for n in nodes:
+                plan = (n.get("plan") or "").replace('"', '""')
+                print(
+                    f"{n.get('global_step', '')},{n.get('run_id', '')},{n.get('step', '')},"
+                    f'{n.get("metric_value", "")},"{plan}",{n.get("node_id", "")}'
+                )
+        else:
+            print(f"step,{metric_name},plan,node_id")
+            for n in nodes:
+                plan = (n.get("plan") or "").replace('"', '""')
+                print(f'{n.get("step", "")},{n.get("metric_value", "")},"{plan}",{n.get("node_id", "")}')
 
     if plot:
-        # For trajectory we need all nodes in step order (not just top N)
-        _run_meta, all_nodes = fetch_nodes(client, run_id, sort="metric", include_code=False)
-        all_by_step = sorted([n for n in all_nodes if n.get("metric_value") is not None], key=lambda n: n.get("step", 0))
+        if lineage:
+            # Already have the lineage-wide set; order by global step for trajectory.
+            all_by_step = sorted(
+                [n for n in nodes if n.get("metric_value") is not None],
+                key=lambda n: n.get("global_step") if n.get("global_step") is not None else 0,
+            )
+        else:
+            # For trajectory we need all nodes in step order (not just top N)
+            _run_meta, all_nodes = fetch_nodes(client, run_id, sort="metric", include_code=False)
+            all_by_step = sorted([n for n in all_nodes if n.get("metric_value") is not None], key=lambda n: n.get("step", 0))
         if all_by_step:
             values = [n["metric_value"] for n in all_by_step]
             best_val = run_meta.get("best_metric", values[0])
@@ -79,4 +143,5 @@ def handle(run_id: str, top: Optional[int], format: str, plot: bool, include_cod
             first_val = values[0]
             spark = _sparkline(values)
             total = len(all_by_step)
-            print(f"\nSteps 0-{total}: {first_val:.4g} {spark} -> {best_val:.4g} (best at step {best_step})")
+            label = "Lineage steps" if lineage else "Steps"
+            print(f"\n{label} 0-{total}: {first_val:.4g} {spark} -> {best_val:.4g} (best at step {best_step})")

--- a/weco/commands/run/show.py
+++ b/weco/commands/run/show.py
@@ -5,14 +5,35 @@ import sys
 
 from rich.console import Console
 
-from .. import make_client, fetch_nodes
+from .. import make_client, fetch_nodes, resolve_lineage_id, fetch_lineage
+
+
+def _lineage_best_node(client, run_id: str) -> tuple[dict | None, str | None]:
+    """Resolve the lineage-global best node — the same node `derive --from-step
+    best` branches from. Returns ``(node, best_run_id)`` with the node hydrated
+    via its owning run so it carries code/parent_step, or ``(None, None)``."""
+    lineage_id = resolve_lineage_id(client, run_id)
+    lineage = fetch_lineage(client, lineage_id)
+    best = lineage.get("best")
+    if not best:
+        return None, None
+    best_run_id = best.get("run_id")
+    _meta, nodes = fetch_nodes(client, best_run_id, step=best.get("step"))
+    return (nodes[0] if nodes else None), best_run_id
 
 
 def handle(run_id: str, step: str, console: Console) -> None:
     """Show details for a specific step/node."""
     client = make_client(console)
 
+    best_run_id = run_id
     if step == "best":
+        # Lineage-global best, consistent with `derive --from-step best`.
+        node, best_run_id = _lineage_best_node(client, run_id)
+        if not node:
+            print(json.dumps({"error": "No scored nodes found in lineage"}))
+            sys.exit(1)
+    elif step == "run-best":
         _run_meta, nodes = fetch_nodes(client, run_id, sort="metric", top=1)
         if not nodes:
             print(json.dumps({"error": "No scored nodes found"}))
@@ -22,7 +43,7 @@ def handle(run_id: str, step: str, console: Console) -> None:
         try:
             step_num = int(step)
         except ValueError:
-            print(json.dumps({"error": f"Invalid step: {step}. Use an integer or 'best'"}))
+            print(json.dumps({"error": f"Invalid step: {step}. Use an integer, 'best', or 'run-best'"}))
             sys.exit(1)
         _run_meta, nodes = fetch_nodes(client, run_id, step=step_num)
         if not nodes:
@@ -40,5 +61,9 @@ def handle(run_id: str, step: str, console: Console) -> None:
         "status": node.get("status"),
         "is_buggy": node.get("is_buggy"),
     }
+    # When resolved across the lineage, surface which run holds the best node so
+    # the agent isn't misled into thinking it belongs to the queried run.
+    if step == "best" and best_run_id and best_run_id != run_id:
+        output["run_id"] = best_run_id
 
     print(json.dumps(output, indent=2))

--- a/weco/commands/run/status.py
+++ b/weco/commands/run/status.py
@@ -4,12 +4,65 @@ import json
 
 from rich.console import Console
 
-from .. import make_client, fetch_nodes, fetch_run
+from .. import make_client, fetch_nodes, fetch_run, resolve_lineage_id, fetch_lineage, fetch_lineage_nodes
+
+# Statuses that mean the run/lineage is still working — used to decide whether
+# to surface the agent operating contract.
+_ACTIVE_STATUSES = ("running", "stopping", "pending_approval", "pending_evaluation")
+
+# Just-in-time operating contract for an agent driving this run. Surfaced on the
+# canonical progress check (not buried in a doc read once at the start) so it
+# lands at the decision point every monitoring cycle: the run is self-driving,
+# so stay responsive to the user and act via derive/stop.
+_AGENT_GUIDANCE = (
+    "This run is self-driving — do NOT tail logs or use any blocking/streaming watch; "
+    "just poll this command (it returns immediately). Between polls you remain available "
+    "to the user: if they send a message, acknowledge and act on it before polling again — "
+    'steer with `weco run derive <run-id> --from-step best -i "<direction>"` (works mid-run, '
+    "no need to stop first), or abort with `weco run stop <run-id>`. For the full lineage "
+    "picture across all derived runs (global best, tree), use `weco run overview <run-id>`."
+)
 
 
-def handle(run_id: str, console: Console) -> None:
+def _lineage_status(client, run_id: str) -> dict:
+    """Lineage-wide aggregate status across every derived run in the lineage."""
+    lineage_id = resolve_lineage_id(client, run_id)
+    lineage = fetch_lineage(client, lineage_id)
+    pending = fetch_lineage_nodes(client, lineage_id, status="pending_approval,pending_evaluation")
+    pending_nodes = [
+        {"node_id": n.get("id"), "run_id": n.get("run_id"), "global_step": n.get("global_step"), "step": n.get("step")}
+        for n in pending
+    ]
+    best = lineage.get("best") or {}
+    output = {
+        "lineage_id": lineage.get("id", lineage_id),
+        "scope": "lineage",
+        "status": lineage.get("status"),
+        "name": lineage.get("name"),
+        "current_step": lineage.get("current_step"),
+        "total_steps": lineage.get("total_steps"),
+        "best_metric": lineage.get("best_metric"),
+        "best_step": best.get("step"),
+        "best_run_id": best.get("run_id"),
+        "metric_name": lineage.get("metric_name"),
+        "goal": "maximize" if lineage.get("maximize") else "minimize",
+        "member_count": lineage.get("member_count"),
+        "active_member_count": lineage.get("active_member_count"),
+        "require_review": lineage.get("require_review", False),
+        "pending_nodes": pending_nodes,
+    }
+    if lineage.get("status") in _ACTIVE_STATUSES:
+        output["agent_guidance"] = _AGENT_GUIDANCE
+    return output
+
+
+def handle(run_id: str, lineage: bool, console: Console) -> None:
     """Show run status and progress as JSON."""
     client = make_client(console)
+
+    if lineage:
+        print(json.dumps(_lineage_status(client, run_id), indent=2))
+        return
 
     # Single call: run metadata + pending nodes (no code)
     run_meta, pending_raw = fetch_nodes(client, run_id, status="pending_approval,pending_evaluation", include_code=False)
@@ -31,18 +84,8 @@ def handle(run_id: str, console: Console) -> None:
         "pending_nodes": pending_nodes,
     }
 
-    # Just-in-time operating contract for an agent driving this run. Surfaced
-    # on the canonical progress check (not buried in a doc read once at the
-    # start) so it lands at the decision point every monitoring cycle: the run
-    # is self-driving, so stay responsive to the user and act via derive/stop.
-    if run_meta.get("status") in ("running", "pending_approval", "pending_evaluation"):
-        output["agent_guidance"] = (
-            "This run is self-driving — do NOT tail logs or use any blocking/streaming watch; "
-            "just poll this command (it returns immediately). Between polls you remain available "
-            "to the user: if they send a message, acknowledge and act on it before polling again — "
-            'steer with `weco run derive <run-id> --from-step best -i "<direction>"` (works mid-run, '
-            "no need to stop first), or abort with `weco run stop <run-id>`."
-        )
+    if run_meta.get("status") in _ACTIVE_STATUSES:
+        output["agent_guidance"] = _AGENT_GUIDANCE
 
     # Add lineage info if present (requires full run status fetch)
     try:

--- a/weco/core/api.py
+++ b/weco/core/api.py
@@ -406,6 +406,35 @@ class WecoClient:
         resp.raise_for_status()
         return resp.json()
 
+    def list_lineage_nodes(
+        self, lineage_id: str, *, node_ids: list[str] | None = None, include_details: bool = False, status: str | None = None
+    ) -> dict:
+        """``GET /lineages/{lineage_id}/nodes`` — flat list of nodes across every
+        member of a lineage, each carrying a lineage-global ``global_step``.
+
+        Heavy fields (``plan``, ``analysis``, ``code``, ``execution_output``) are
+        omitted unless ``include_details=True``; keep them off the polling path.
+
+        Args:
+            lineage_id: The lineage UUID (= root run ID).
+            node_ids: Optional subset of node IDs to fetch (also hydrates details).
+            include_details: Include the heavy fields.
+            status: Comma-separated node statuses to filter by.
+
+        Raises:
+            requests.exceptions.HTTPError: On non-2xx responses.
+        """
+        params: dict[str, Any] = {}
+        if node_ids:
+            params["node_ids"] = node_ids
+        if include_details:
+            params["include_details"] = True
+        if status:
+            params["status"] = status
+        resp = self._get(f"/lineages/{lineage_id}/nodes", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
     def resume_run(self, run_id: str, *, api_keys: dict[str, str] | None = None, steps: int | None = None) -> dict:
         """``POST /runs/{run_id}/resume`` — resume an interrupted or completed run.
 


### PR DESCRIPTION
## Lineage-wide run inspection in the CLI

The `weco run` read commands were single-run scoped — once a run had been `derive`d,  an agent (or user) couldn't see the global best, the derived branches, or the tree    the way the dashboard does. This adds lineage-aware inspection on top of the          existing per-run commands. No backend changes — the lineage endpoints already exist.
  ### New  - **`weco run overview <run-id>`**

The full lineage picture in one call (dashboard parity). Pass any run ID in the lineage; returns the aggregate (status, global best   metric, summed steps, member counts), the global best node across all runs, the member tree (each with its `derived_from` branch point, per-member best, and          children), and the `global_step`-ordered node list. Supports `--plot` (lineage-wide   trajectory) and `--include-code`.
  - `WecoClient.list_lineage_nodes()` (`GET /lineages/{id}/nodes`) and shared helpers   `resolve_lineage_id` / `fetch_lineage` / `fetch_lineage_nodes`.

  ### Changed                                                                           - **`status` / `results`** gain `--lineage` to scope across all derived runs.
  Per-run stays the default - fully backward compatible. Lineage rows are labelled by   `global_step` with `run:step` secondary, matching the dashboard.

- **`show` / `diff`**: `--step best` now resolves the **lineage-best** node - the     same one `derive --from-step best` branches from — and surfaces its `run_id` when it lives in a different sub-run. Added `--step run-best` for the best within just the queried run. (Fixes the prior inconsistency where `best` meant run-best here but lineage-best in `derive`.)