### PR TITLE
Remove session URL from headless output. Bump version (0.3.40)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "weco"
 authors = [{ name = "Weco AI Team", email = "contact@weco.ai" }]
 description = "Documentation for `weco`, a CLI for using Weco AI's code optimizer."
 readme = "README.md"
-version = "0.3.39"
+version = "0.3.40"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [

--- a/weco/commands/start/tui_bridge.py
+++ b/weco/commands/start/tui_bridge.py
@@ -170,9 +170,6 @@ def run_headless_bridge(
         seed_prompt=seed_prompt,
     )
 
-    if orchestrator.dashboard_url:
-        console.print(f"[green]Bridged session live.[/] Watch and steer at: [bold]{orchestrator.dashboard_url}[/]")
-
     try:
         asyncio.run(orchestrator.run_until_stopped())
     except KeyboardInterrupt:


### PR DESCRIPTION
- Remove session URL from headless output (doesn't exist)
- Bump version (0.3.40)