### PR TITLE
Handle ResumeResponse.is_done from the K-parallel backend

### DIFF
--- a/tests/test_auto_resume.py
+++ b/tests/test_auto_resume.py
@@ -2,7 +2,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from weco.optimizer import AutoResumePolicy, OptimizationResult, _is_transient, _run_loop_with_auto_resume
+from weco.optimizer import (
+    AutoResumePolicy,
+    OptimizationResult,
+    _is_transient,
+    _run_loop_with_auto_resume,
+    _SilentResumeOutcome,
+)
 
 
 class FakeUI:
@@ -11,12 +17,16 @@ class FakeUI:
         self.reconnected: int = 0
         self.errors: list[str] = []
         self.warnings: list[str] = []
+        self.completed: list[int] = []
 
     def on_reconnecting(self, attempt: int, max_attempts: int, backoff_s: float) -> None:
         self.reconnecting.append((attempt, max_attempts, backoff_s))
 
     def on_reconnected(self) -> None:
         self.reconnected += 1
+
+    def on_complete(self, total_steps: int) -> None:
+        self.completed.append(total_steps)
 
     def on_error(self, message: str) -> None:
         self.errors.append(message)
@@ -40,12 +50,19 @@ def stub_sleep(monkeypatch):
 def stub_resume(monkeypatch):
     calls: list[str] = []
 
-    def _install(outcomes: list[bool]):
+    def _install(outcomes: list):
+        # Accept plain bools for readability (True -> RESUMED, False -> FAILED)
+        # as well as explicit _SilentResumeOutcome members (e.g. ALREADY_COMPLETE).
         iterator = iter(outcomes)
 
         def _fake(run_id, auth_headers, api_keys):
             calls.append(run_id)
-            return next(iterator)
+            value = next(iterator)
+            if value is True:
+                return _SilentResumeOutcome.RESUMED
+            if value is False:
+                return _SilentResumeOutcome.FAILED
+            return value
 
         monkeypatch.setattr("weco.optimizer._silent_resume", _fake)
         return calls
@@ -181,6 +198,41 @@ def test_silent_resume_exhaustion_without_reinvoking_loop(stub_sleep, stub_resum
     assert ui.reconnected == 0
     assert len(ui.errors) == 1
     assert "exhausted after 2" in ui.errors[0]
+
+
+def test_silent_resume_already_complete_exits_success_without_reinvoking_loop(stub_sleep, stub_resume):
+    # Backend's resume repair pass finalized the run itself (is_done). The wrapper
+    # must NOT re-enter the loop (which would poll a completed run and misreport a
+    # stop) — it returns a completed result and fires on_complete once.
+    resume_calls = stub_resume([_SilentResumeOutcome.ALREADY_COMPLETE])
+    transient = _make_result("transient_network_error", final_step=6)
+
+    returned, factory, ui = _drive([transient], policy=AutoResumePolicy(max_attempts=3))
+
+    assert returned.success is True
+    assert returned.status == "completed"
+    assert returned.reason == "completed_successfully"
+    assert returned.final_step == 6
+    assert factory.call_count == 1  # loop entered exactly once, never re-invoked
+    assert resume_calls == ["run-1"]
+    assert ui.reconnected == 1
+    assert ui.completed == [6]
+    assert ui.errors == []
+
+
+def test_silent_resume_retries_then_already_complete(stub_sleep, stub_resume):
+    # A failed attempt retries; a subsequent ALREADY_COMPLETE ends as success.
+    resume_calls = stub_resume([False, _SilentResumeOutcome.ALREADY_COMPLETE])
+    transient = _make_result("transient_network_error", final_step=3)
+
+    returned, factory, ui = _drive([transient], policy=AutoResumePolicy(max_attempts=4))
+
+    assert returned.success is True
+    assert returned.status == "completed"
+    assert factory.call_count == 1
+    assert len(resume_calls) == 2
+    assert ui.completed == [3]
+    assert ui.errors == []
 
 
 def test_backoff_is_exponential_and_capped(stub_sleep, stub_resume):

--- a/tests/test_resume_is_done.py
+++ b/tests/test_resume_is_done.py
@@ -1,0 +1,153 @@
+"""Manual ``weco resume`` handling of the backend's ``is_done`` resume signal.
+
+PR 2's ``/runs/{id}/resume`` endpoint may finalize a run itself: it promotes a
+scored-but-interrupted node, the step budget is met, and the run flips to
+'completed' with no runnable work. It reports this with ``is_done=True`` in the
+resume response. The CLI must:
+
+* short-circuit to a success exit WITHOUT entering the task-polling loop when
+  ``is_done`` is true (otherwise it polls a completed run and misreports a stop);
+* preserve the exact legacy path when ``is_done`` is absent (older backend).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import weco.optimizer as optimizer
+from weco.optimizer import OptimizationResult, resume_optimization
+
+
+def _status(**overrides):
+    base = {
+        "status": "terminated",
+        "objective": {"metric_name": "accuracy", "maximize": True, "evaluation_command": "python eval.py"},
+        "optimizer": {"steps": 10, "code_generator": {"model": "o4-mini"}, "evaluator": {"model": "o4-mini"}},
+        "current_step": 4,
+        "run_name": "demo-run",
+        "updated_at": "2026-07-13T00:00:00Z",
+        "lineage_id": "lineage-1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _resume_resp(**overrides):
+    base = {
+        "source_code": {"solution.py": "print('fallback')"},
+        "run_name": "demo-run",
+        "log_dir": ".runs",
+        "save_logs": False,
+        "eval_timeout": None,
+        "steps": 10,
+        "best_metric_value": 0.9,
+        "best_step": 3,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def common_mocks(monkeypatch):
+    """Patch resume_optimization's boundaries; return the mock registry."""
+    mocks = {
+        "auth": MagicMock(return_value=("key", {"Authorization": "Bearer x"})),
+        "status": MagicMock(return_value=_status()),
+        "resume": MagicMock(),
+        "loop": MagicMock(),
+        "apply": MagicMock(),
+    }
+    monkeypatch.setattr(optimizer, "handle_authentication", mocks["auth"])
+    monkeypatch.setattr(optimizer, "get_optimization_run_status", mocks["status"])
+    monkeypatch.setattr(optimizer, "resume_optimization_run", mocks["resume"])
+    monkeypatch.setattr(optimizer, "_run_loop_with_auto_resume", mocks["loop"])
+    monkeypatch.setattr(optimizer, "offer_apply_best_solution", mocks["apply"])
+    # Confirm.ask ("kept files unchanged?") -> yes
+    monkeypatch.setattr(optimizer.Confirm, "ask", staticmethod(lambda *a, **k: True))
+    # Never touch the real filesystem lock / heartbeat / drain / termination.
+    monkeypatch.setattr(optimizer, "try_acquire", MagicMock(return_value=object()))
+    monkeypatch.setattr(optimizer, "release", MagicMock())
+    monkeypatch.setattr(optimizer, "_drain_lineage_remainder", MagicMock())
+    monkeypatch.setattr(optimizer, "report_termination", MagicMock(return_value=True))
+    monkeypatch.setattr(optimizer, "LineageHeartbeatSender", MagicMock())
+    return mocks
+
+
+def test_is_done_true_exits_success_without_entering_task_loop(common_mocks):
+    common_mocks["resume"].return_value = _resume_resp(is_done=True)
+
+    result = resume_optimization("run-1", output_mode="plain", no_open=True)
+
+    assert result is True
+    # The task-polling loop was never entered.
+    common_mocks["loop"].assert_not_called()
+    # Best-solution handling still runs, matching normal completion.
+    common_mocks["apply"].assert_called_once()
+
+
+def test_is_done_absent_preserves_legacy_loop_path(common_mocks):
+    # Old backend: response carries no is_done field at all.
+    common_mocks["resume"].return_value = _resume_resp()
+    common_mocks["loop"].return_value = OptimizationResult(
+        success=True, final_step=10, status="completed", reason="completed_successfully"
+    )
+
+    result = resume_optimization("run-1", output_mode="plain", no_open=True)
+
+    assert result is True
+    # Legacy behavior unchanged: the task-polling loop IS entered.
+    common_mocks["loop"].assert_called_once()
+
+
+def test_is_done_false_preserves_legacy_loop_path(common_mocks):
+    # Newer backend that explicitly reports there is still work to do.
+    common_mocks["resume"].return_value = _resume_resp(is_done=False)
+    common_mocks["loop"].return_value = OptimizationResult(
+        success=True, final_step=10, status="completed", reason="completed_successfully"
+    )
+
+    result = resume_optimization("run-1", output_mode="plain", no_open=True)
+
+    assert result is True
+    common_mocks["loop"].assert_called_once()
+
+
+def test_is_done_acquires_consumer_lock_before_applying(common_mocks, monkeypatch):
+    """B2: the is_done short-circuit writes candidate files into the working tree via
+    offer_apply_best_solution, so it MUST hold the consumer lock first — exactly as
+    the normal completion path does. Assert lock is acquired BEFORE the apply and
+    released AFTER, so a concurrent consumer in the same tree is never raced."""
+    common_mocks["resume"].return_value = _resume_resp(is_done=True)
+
+    calls = []
+    handle = object()
+    monkeypatch.setattr(optimizer, "try_acquire", MagicMock(side_effect=lambda *a, **k: calls.append("acquire") or handle))
+    monkeypatch.setattr(optimizer, "release", MagicMock(side_effect=lambda h: calls.append("release")))
+    common_mocks["apply"].side_effect = lambda *a, **k: calls.append("apply")
+
+    result = resume_optimization("run-1", output_mode="plain", no_open=True)
+
+    assert result is True
+    common_mocks["loop"].assert_not_called()
+    # Ordering: lock acquired -> apply -> lock released.
+    assert calls == ["acquire", "apply", "release"], calls
+    optimizer.release.assert_called_once_with(handle)
+
+
+def test_is_done_lock_unavailable_skips_apply_still_success(common_mocks, monkeypatch):
+    """B2: another consumer already holds the working-tree lock. The apply MUST be
+    skipped (so we don't clobber that consumer's in-flight eval), but the run is
+    still complete, so the resume reports success (returns True)."""
+    common_mocks["resume"].return_value = _resume_resp(is_done=True)
+
+    # try_acquire returns None -> lock held by someone else.
+    monkeypatch.setattr(optimizer, "try_acquire", MagicMock(return_value=None))
+    monkeypatch.setattr(optimizer, "release", MagicMock())
+
+    result = resume_optimization("run-1", output_mode="plain", no_open=True)
+
+    assert result is True
+    common_mocks["loop"].assert_not_called()
+    # Lock was unavailable -> no apply, and nothing to release.
+    common_mocks["apply"].assert_not_called()
+    optimizer.release.assert_not_called()

--- a/tests/test_submit_terminated_race.py
+++ b/tests/test_submit_terminated_race.py
@@ -1,0 +1,66 @@
+"""Regression: a /suggest submit that 409s (run terminated mid-race) is an error,
+never a false success.
+
+PR 2's backend converges a raced hard stop to an HTTP 409 on the submit
+(``/suggest``) call: if a hard stop wins the completion race, the backend returns
+409 instead of a truthful-looking ``is_done=true`` (which the CLI would otherwise
+map to ``success=True``/``status="completed"``). This test pins that the CLI's
+loop treats that 409 as a stop/error outcome — it must NOT call ``ui.on_complete``
+and must NOT report ``success=True`` or ``status="completed"``.
+"""
+
+from unittest.mock import MagicMock
+
+import requests
+
+from weco.core.api import ExecutionTasksResult, RunSummary
+from weco.optimizer import run_optimization_loop
+
+
+def _http_409(detail: str = "Run status is `terminated`") -> requests.exceptions.HTTPError:
+    resp = requests.Response()
+    resp.status_code = 409
+    resp._content = f'{{"detail":"{detail}"}}'.encode()
+    return requests.exceptions.HTTPError(response=resp)
+
+
+def test_submit_409_terminated_is_not_reported_as_success(monkeypatch):
+    """One task claimed and evaluated; the submit 409s (hard stop won the race).
+
+    The loop must surface an error result (success=False, status != 'completed')
+    and never signal completion to the UI.
+    """
+    # Run is live; a single ready task is waiting.
+    monkeypatch.setattr("weco.optimizer.get_optimization_run_status", MagicMock(return_value={"status": "running"}))
+    tasks_result = ExecutionTasksResult(tasks=[{"id": "task-1"}], run=RunSummary(id="run-1", status="running"))
+    monkeypatch.setattr("weco.optimizer.get_execution_tasks", MagicMock(return_value=tasks_result))
+    monkeypatch.setattr(
+        "weco.optimizer.claim_execution_task", MagicMock(return_value={"revision": {"code": {"main.py": "pass"}, "plan": "p"}})
+    )
+    monkeypatch.setattr("weco.optimizer.run_evaluation_with_files_swap", MagicMock(return_value="metric: 0.9"))
+    # The submit races a hard stop and 409s.
+    monkeypatch.setattr("weco.optimizer.submit_execution_result", MagicMock(side_effect=_http_409()))
+
+    ui = MagicMock()
+    artifacts = MagicMock()
+
+    result = run_optimization_loop(
+        ui=ui,
+        run_id="run-1",
+        auth_headers={"Authorization": "Bearer x"},
+        source_code={"main.py": "pass"},
+        eval_command="python eval.py",
+        eval_timeout=None,
+        artifacts=artifacts,
+        save_logs=False,
+    )
+
+    # A raced-terminated 409 is an error outcome, NOT a completion.
+    assert result.success is False
+    assert result.status != "completed"
+    assert result.reason == "http_409"
+    # The UI must never be told the run completed.
+    ui.on_complete.assert_not_called()
+    # The error was surfaced to the user with the backend detail.
+    ui.on_error.assert_called_once()
+    assert "terminated" in ui.on_error.call_args.args[0].lower()

--- a/weco/optimizer.py
+++ b/weco/optimizer.py
@@ -118,13 +118,36 @@ def _classify_lineage_poll(read_ok: bool, has_ready: bool, active_run_count: Opt
     return _PollAction.DONE
 
 
-def _silent_resume(run_id: str, auth_headers: dict, api_keys: Optional[dict]) -> bool:
-    """Flip a run back to 'running' without emitting any console output."""
+class _SilentResumeOutcome(Enum):
+    """Result of a background (no-console-output) resume attempt.
+
+    Distinguishes the three cases the auto-resume wrapper must act on
+    differently: the run was flipped back to ``running`` and has work to do
+    (``RESUMED``); the backend's resume repair pass found no runnable work and
+    already finalized the run ``completed`` (``ALREADY_COMPLETE``, signalled by
+    ``is_done`` in the resume response); or the resume call failed and should be
+    retried (``FAILED``).
+    """
+
+    RESUMED = "resumed"
+    ALREADY_COMPLETE = "already_complete"
+    FAILED = "failed"
+
+
+def _silent_resume(run_id: str, auth_headers: dict, api_keys: Optional[dict]) -> _SilentResumeOutcome:
+    """Flip a run back to 'running' without emitting any console output.
+
+    Reads ``is_done`` from the resume response defensively (absent → ``False``),
+    so an older backend that never sends the field is treated as a normal
+    ``RESUMED`` and legacy behavior is preserved.
+    """
     try:
-        WecoClient(auth_headers).resume_run(run_id, api_keys=api_keys)
-        return True
+        resp = WecoClient(auth_headers).resume_run(run_id, api_keys=api_keys)
     except Exception:
-        return False
+        return _SilentResumeOutcome.FAILED
+    if isinstance(resp, dict) and resp.get("is_done", False):
+        return _SilentResumeOutcome.ALREADY_COMPLETE
+    return _SilentResumeOutcome.RESUMED
 
 
 def _run_loop_with_auto_resume(
@@ -161,7 +184,18 @@ def _run_loop_with_auto_resume(
             ui.on_reconnecting(attempts_used, policy.max_attempts, backoff)
             time.sleep(backoff)
 
-            if _silent_resume(run_id, auth_headers, api_keys):
+            outcome = _silent_resume(run_id, auth_headers, api_keys)
+            if outcome is _SilentResumeOutcome.ALREADY_COMPLETE:
+                # The backend's resume repair pass finalized the run 'completed'
+                # (no runnable work left). Re-entering the loop would only poll,
+                # observe run.status == 'completed', and misreport a stop. Treat
+                # it as terminal success — the same exit a normal is_done takes.
+                ui.on_reconnected()
+                ui.on_complete(result.final_step)
+                return OptimizationResult(
+                    success=True, final_step=result.final_step, status="completed", reason="completed_successfully"
+                )
+            if outcome is _SilentResumeOutcome.RESUMED:
                 ui.on_reconnected()
                 start_step = result.final_step
                 resumed = True
@@ -908,6 +942,60 @@ def resume_optimization(
 
     dashboard_url = f"{__dashboard_url__}/runs/{run_id}"
     run_name = resume_resp.get("run_name", run_id)
+
+    # The backend's resume repair pass may have finalized the run itself: a
+    # scored-but-interrupted node was promoted, the step budget was met, and the
+    # run was flipped to 'completed' with no runnable work. It signals this with
+    # is_done=True (read defensively: an older backend omits the field, yielding
+    # False and the unchanged legacy behavior below). Entering the task-polling
+    # loop here would find no tasks / a completed run and misreport it as
+    # stopped, so short-circuit to a success exit that mirrors normal completion.
+    if bool(resume_resp.get("is_done", False)):
+        if daemon:
+            # Emit the identifiers stdout-watchers (claude, cursor, the wrapper's
+            # find_run_ids) rely on before we return — no fork needed, there is
+            # no long-running work to detach.
+            print(f"Run ID: {run_id}", flush=True)
+            print(f"Run name: {run_name}", flush=True)
+            print(f"Dashboard: {dashboard_url}", flush=True)
+        if output_mode == "plain":
+            print("")
+            print("=" * 60)
+            print("[COMPLETE] Run already complete")
+            print("=" * 60, flush=True)
+        else:
+            console.print("\n[bold green]Run already complete![/]")
+        # Offer/apply the best solution exactly as the normal completion path
+        # does, so a resume that finds the run already done still lands the
+        # winning code in the working tree (or reports where it was saved).
+        #
+        # offer_apply_best_solution writes candidate files into the working tree,
+        # so it MUST hold the consumer lock — same as the normal completion path,
+        # which applies under lock_handle and only releases afterwards. Without it,
+        # a consumer already draining this lineage in the same tree could be
+        # mid-eval (swapping files in/out) when we overwrite its files. If that
+        # consumer holds the lock, skip the apply with the same message the normal
+        # path gives on lock-unavailable; the run is still complete, so report
+        # success either way.
+        lock_handle = try_acquire()
+        if lock_handle is None:
+            console.print(
+                "[yellow]Another Weco optimization is already evaluating in this directory; "
+                "not starting a second consumer here.[/]"
+            )
+            return True
+        try:
+            offer_apply_best_solution(
+                console=console,
+                run_id=run_id,
+                source_code=source_code,
+                artifacts=RunArtifacts(log_dir=log_dir, run_id=run_id),
+                auth_headers=auth_headers,
+                apply_change=apply_change,
+            )
+        finally:
+            release(lock_handle)
+        return True
 
     if daemon:
         # Print everything stdout-watchers (claude, cursor, the wrapper's find_run_ids)


### PR DESCRIPTION
> This branch contains the full parallelization backend work: the foundational correctness commit (atomic step allocation / task attribution / completion CAS) and the K-parallel feature commit described below. Deploy order: supabase migration -> meta-agent -> CLI patch.

# fix: handle ResumeResponse.is_done from PR-2 backend (patch release)

The PR-2 backend's `/runs/{id}/resume` can finalize a run itself (promote a
scored-but-interrupted node → step budget met → run flipped `completed`, no runnable
work), signalling it with a new additive `is_done: bool` on ResumeResponse. This
backend deploys BEFORE the CLI's parallel features, so today's CLI must handle it.

**Bug (pre-fix):** `is_done` was ignored. Manual `weco resume` entered the
task-polling loop, saw `run.status == "completed"`, and returned
`OptimizationResult(success=False, reason="user_requested_stop")` — reporting a
completed run as stopped/failed (`weco/optimizer.py:307-317`, entered at `:998`).
The silent auto-resume path (`_silent_resume` returning a bare bool) re-entered the
loop and hit the same misreport.

**Fix (`weco/optimizer.py`):**
- `is_done` is parsed **defensively** — absent → `False`, so the CLI stays correct
  against an older backend (unchanged legacy behavior).
- Manual `resume_optimization` short-circuits on `is_done`: prints a "Run already
  complete" success message (matching the existing completion output), reuses
  `offer_apply_best_solution` to fetch/apply the winning code, and exits `True`
  **without entering the task loop**.
- `_silent_resume` now returns `_SilentResumeOutcome{RESUMED, ALREADY_COMPLETE,
  FAILED}`; `_run_loop_with_auto_resume` treats `ALREADY_COMPLETE` as terminal
  success (fires `on_complete`, returns a `completed` result, stops retrying) —
  mirroring how a normal is_done exits the loop.

**Tests:** `tests/test_resume_is_done.py` (is_done true → no loop / success; is_done
absent → legacy loop path; is_done false → legacy loop path) and two new cases in
`tests/test_auto_resume.py` for the `ALREADY_COMPLETE` outcome. Fully mocked, no
network. Run: `pytest tests/test_auto_resume.py tests/test_resume_is_done.py`.

Ships last in the deploy order (supabase → meta-agent → **CLI**).
