### PR TITLE
docs: lead with agent & harness engineering in README use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Weco systematically optimizes your code, guided directly by your evaluation metr
 
 Example applications include:
 
-- **GPU Kernel Optimization**: Reimplement PyTorch functions using [CUDA](/examples/cuda/README.md) or [Triton](/examples/triton/README.md), optimizing for `latency`, `throughput`, or `memory_bandwidth`.
+- **Agent & Harness Engineering**: Improve the harness around your LLM agents, from prompts and tools to [agentic scaffolding](/examples/extract-line-plot/README.md), optimizing for `accuracy`, `win_rate`, or `cost`.
+- **Prompt Engineering**: Refine prompts for LLMs (e.g., for [math problems](/examples/prompt/README.md)) or [compress them](/examples/prompt-compression/README.md) while holding accuracy, optimizing for `win_rate`, `relevance`, or `format_adherence`.
 - **Model Development**: Tune feature transformations, architectures or [the whole training pipeline](/examples/spaceship-titanic/README.md), optimizing for `validation_accuracy`, `AUC`, or `Sharpe Ratio`.
-- **Prompt Engineering**: Refine prompts for LLMs (e.g., for [math problems](/examples/prompt/README.md)), optimizing for `win_rate`, `relevance`, or `format_adherence`
+- **General Performance Optimization**: Speed up any code with a measurable objective, including GPU kernels in [CUDA](/examples/cuda/README.md) or [Triton](/examples/triton/README.md), optimizing for `latency`, `throughput`, or `memory_bandwidth`.
 
 ![image](assets/example-optimization.gif)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 ## Weco Examples
 
-Explore runnable examples that show how to use Weco to optimize ML models, prompts, and GPU kernels. Pick an example and get going in minutes.
+Explore runnable examples that show how to use Weco to optimize agent harnesses, prompts, ML models, and other performance-critical code. Pick an example and get going in minutes.
 
 ### Table of Contents
 


### PR DESCRIPTION
The README's example-applications list led with GPU-kernel rewriting, which is how investor/customer AI agents summarize Weco (an investor's agent concluded kernel-layer company from exactly this section; raised by Zhengyao in #marketing today). This reorders the list so Agent & Harness Engineering leads (linking the existing agentic-scaffolding and prompt-compression examples), and folds CUDA/Triton kernels into a General Performance Optimization bullet. examples/README.md intro updated to match. No content removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)